### PR TITLE
Update Cypress ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           override-ci-command: npm ci
       - run:
           name: build
-          command: npm run build      
+          command: npm run build
       # Save workspace for subsequent jobs (i.e. test)
       - persist_to_workspace:
           root: .
@@ -41,13 +41,16 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build      
+      - build
       - test:
           requires:
             - build
-      - cypress/run:        
+      - cypress/run:
           requires:
-            - build          
+            - build
           start: npm start
           wait-on: 'http://localhost:3000'
           store_artifacts: true
+          post-steps:
+            - store_test_results:
+                path: cypress/results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,3 +50,4 @@ workflows:
             - build          
           start: npm start
           wait-on: 'http://localhost:3000'
+          store_artifacts: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /coverage
 /cypress/videos
 /cypress/screenshots
+cypress/results
 
 # production
 /build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![ClimateMind](https://circleci.com/gh/ClimateMind/climatemind-frontend.svg?style=shield)](https://app.circleci.com/pipelines/github/ClimateMind/climatemind-frontend)
 
+[![Cypress.io](https://img.shields.io/badge/tested%20with-Cypress-04C38E.svg)](https://www.cypress.io/)
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
 ## Available Scripts

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,8 @@
 {
-  "baseUrl": "http://localhost:3000"
+  "baseUrl": "http://localhost:3000",
+  "reporter": "junit",
+  "reporterOptions": {
+    "mochaFile": "cypress/results/cypress-results.xml",
+    "toConsole": true
+  }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -3,6 +3,6 @@
   "reporter": "junit",
   "reporterOptions": {
     "mochaFile": "cypress/results/cypress-results.xml",
-    "toConsole": true
+    "toConsole": false
   }
 }


### PR DESCRIPTION
Updates CI config so videos of the Cypress' tests (if a test fails, using the video is often the easiest way to see exactly why) and any screenshots that are captured (Cypress automatically captures a screenshot on a failure) are stored in Circle CI.

Also updates Cypress reporting so it outputs to an xml file, which CircleCI can then use.

See the artifacts tab for videos/screenshots, and the tests tab the nicely formatted xml - https://app.circleci.com/pipelines/github/ClimateMind/climatemind-frontend/20/workflows/9920f6a7-2766-4cf3-9ce5-8937454c5b84/jobs/44