### PR TITLE
test accessibility with cypress-axe

### DIFF
--- a/cypress/integration/homepage.spec.ts
+++ b/cypress/integration/homepage.spec.ts
@@ -1,10 +1,12 @@
 /// <reference types="cypress" />
 
+import {terminalLog} from '../support/helpers.ts'
+
 describe('Homepage loads and looks correct', () => {
   it('can open homepage', () => {
     cy.visit('');
     cy.contains('Get started').should('be.visible');
-    cy.checkAccessibility()
+    cy.checkAccessibility(terminalLog)
     cy.percySnapshot('Homepage');
   });
 });

--- a/cypress/integration/homepage.spec.ts
+++ b/cypress/integration/homepage.spec.ts
@@ -4,6 +4,7 @@ describe('Homepage loads and looks correct', () => {
   it('can open homepage', () => {
     cy.visit('');
     cy.contains('Get started').should('be.visible');
+    cy.checkAccessibility()
     cy.percySnapshot('Homepage');
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -21,4 +21,16 @@ module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   on('task', percyHealthCheck);
+  on('task', {
+    log(message) {
+      console.log(message)
+
+      return null
+    },
+    table(message) {
+      console.table(message)
+
+      return null
+    }
+  })
 };

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,7 +26,7 @@
 
 import '@percy/cypress';
 
-Cypress.Commands.add('checkAccessibility', () => {
+Cypress.Commands.add('checkAccessibility', (logType) => {
   cy.injectAxe()
-  cy.checkA11y()
+  cy.checkA11y(null, null, logType)
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -28,5 +28,7 @@ import '@percy/cypress';
 
 Cypress.Commands.add('checkAccessibility', (logType) => {
   cy.injectAxe()
-  cy.checkA11y(null, null, logType)
+  cy.checkA11y(null, {
+    includedImpacts: ['serious', 'critical']
+  }, logType)
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,7 +26,7 @@
 
 import '@percy/cypress';
 
-Cypress.Commands.add('testCommand', () => {
-  // TODO: Delete this once we have real commands that can be used as examples
-  cy.log('Hello')
+Cypress.Commands.add('checkAccessibility', () => {
+  cy.injectAxe()
+  cy.checkA11y()
 })

--- a/cypress/support/helpers.ts
+++ b/cypress/support/helpers.ts
@@ -1,0 +1,19 @@
+export function terminalLog(violations) {
+  cy.task(
+    'log',
+    `${violations.length} accessibility violation${
+      violations.length === 1 ? '' : 's'
+    } ${violations.length === 1 ? 'was' : 'were'} detected`
+  )
+  // pluck specific keys to keep the table readable
+  const violationData = violations.map(
+    ({ id, impact, description, nodes }) => ({
+      id,
+      impact,
+      description,
+      nodes: nodes.length
+    })
+  )
+
+  cy.task('table', violationData)
+}

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -4,8 +4,8 @@
 declare namespace Cypress {
   interface Chainable {
     /**
-     * A test command to show how they're done when using Typescript
+     * A command to check a pages accessibility
     */
-    testCommand(): void;
+    checkAccessibility(): void;
   }
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -17,6 +17,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import 'cypress-axe'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package-lock.json
+++ b/package-lock.json
@@ -6340,6 +6340,12 @@
         }
       }
     },
+    "cypress-axe": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.8.1.tgz",
+      "integrity": "sha512-hX48+r5n7Ns7CHkn601Ag0JiCG1vby5+g7QhlP8X+mkiVYpTLpXAPiiaKFj9QTTCdZSI5+0UqwIxA+ShTsr5tA==",
+      "dev": true
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^3.6.1",
     "@typescript-eslint/parser": "^3.6.1",
     "cypress": "^4.11.0",
+    "cypress-axe": "^0.8.1",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-cypress": "^2.11.1",


### PR DESCRIPTION
Introduces cypress-axe to our test suite to allow simple accessibility testing (https://github.com/avanslaars/cypress-axe).  My aim is just that we'll run the custom command on each page as we test them.

Automated accessibility testing is never perfect, but it's a starting point and will catch some violations.

I've set it up to only fail on serious and critical failures, there are currently three moderate failures on the homepage, see https://dequeuniversity.com/rules/axe/3.5 for fuller descriptions of them:

| id | impact | description |
| --- | --- | --- |
| landmark-one-main | moderate | Ensures the document has only one main landmark and each iframe in the page has at most one main landmark |
| page-has-heading-one | moderate | Ensure that the page, or at least one of its frames contains a level-one heading | 
| region | moderate | Ensures all page content is contained by landmarks |