### PR TITLE
Cypress viewport size

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,7 @@
 {
   "baseUrl": "http://localhost:3000",
+  "viewportHeight": 812,
+  "viewportWidth": 375,
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"

--- a/cypress/integration/homepage.spec.ts
+++ b/cypress/integration/homepage.spec.ts
@@ -4,7 +4,6 @@ import {terminalLog} from '../support/helpers.ts'
 
 describe('Homepage loads and looks correct', () => {
   it('can open homepage', () => {
-    cy.viewport('iphone-x');
     cy.visit('');
     cy.contains('Get Started').should('be.visible');
     cy.checkAccessibility(terminalLog)


### PR DESCRIPTION
Changes the viewport size that all the Cypress tests will use to be that of an iphone-x (sizes taken from https://docs.cypress.io/api/commands/viewport.html#Arguments).

Note that Percy will still be capturing at 3 different sizes so any visual anomalies at different sizes should be caught there.