### PR TITLE
fix: env file for api url

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+// TODO
+// use a variable or placeholder and replace it with value from azure app setting during deploy
+REACT_APP_API_URL=https://app-backend-prod-001.azurewebsites.net


### PR DESCRIPTION
# Using deployed PROD api
### Issue Description
We have an environment variable REACT_APP_API_URL configured with the backend API url in Azure but application doesn't seem to be aware of it. Hence we are facing an `undefined` value in the react application

### Frontend configuration change
- `.env.production` file is added to hold the prod backend url
- This will be picked up by the build scripts and made available for the application

---
## Information on .env file and Azure App Settings
### CRA - react-scripts
Environment variables are setup during the build process of react scripts
- [CRA build script](https://github.com/facebook/create-react-app/blob/025f2739ceb459c79a281ddc6e60d7fd7322ca24/packages/react-scripts/scripts/build.js#L23
)
- [CRA environment variable setup during build process](https://github.com/facebook/create-react-app/blob/025f2739ceb459c79a281ddc6e60d7fd7322ca24/packages/react-scripts/config/env.js#L104)

### Azure Application Settings
REACT_APP_API_URL` is defined in Azure application settings but by the time the code reaches azure the env variables are already set. Azure does inject the variable to the container. But in case of a react app bundled to a static html and not rendered server side, the container variable is not utilized
- [Configuration using docker compose](https://www.freecodecamp.org/news/how-to-implement-runtime-environment-variables-with-create-react-app-docker-and-nginx-7f9d42a91d70/)
- [Configuration using placeholders in html as one answer](https://social.msdn.microsoft.com/Forums/en-US/b5cf1c66-0026-426c-9993-8092457c3ff6/reactjs-apps-on-webapps-how-to-access-appsettings?forum=windowsazurewebsitespreview)

### Next steps
- could we have a placeholder or variable in the `.env` file, say `REACT_APP_API_URL=%API_URL%`
- access value from azure's application settings during dockerfile execution
- replace `%API_URL%` in `.env` file with actual URL from above

## Testing
- console.log
![image](https://user-images.githubusercontent.com/39384804/93561422-c1593800-f949-11ea-9c83-7a0dbb88f457.png)

- 200 OK
![image](https://user-images.githubusercontent.com/39384804/93561459-d8982580-f949-11ea-93e1-cbc8b338cabf.png)

- response message
![image](https://user-images.githubusercontent.com/39384804/93561501-ea79c880-f949-11ea-9f62-7d36959d0eba.png)

## Documentation
- would like to place the above info, links and any solution that we arrive after this someplace... update in PT ? 