### PR TITLE
[CM-108] add test for back button navigation

### DIFF
--- a/cypress/integration/questionnaire.spec.ts
+++ b/cypress/integration/questionnaire.spec.ts
@@ -58,4 +58,14 @@ describe('Questionnaire loads and looks correct', () => {
     cy.contains('Find out my Climate Personality').click()
     cy.url().should('include', '/personal-values')
   });
+
+  it('loads the previous question when using back button', () => {
+    cy.goToNextQuestion();
+    //check back arrow icon is visible
+    cy.get('[data-name="icon/content/add_24px"]').should('be.visible');
+    cy.goToPreviousQuestion();
+    //check that navigating to the next question still works after going back
+    cy.goToNextQuestion();
+  });
+
 });

--- a/cypress/integration/questionnaire.spec.ts
+++ b/cypress/integration/questionnaire.spec.ts
@@ -60,6 +60,10 @@ describe('Questionnaire loads and looks correct', () => {
   });
 
   it('loads the previous question when using back button', () => {
+    cy.contains('Q1.').should('be.visible');
+    cy.get('[data-name="icon/content/add_24px"]').should('not.be.visible');
+    cy.get('[data-testid="PrevButton"]').should('not.be.visible');
+
     cy.goToNextQuestion();
     //check back arrow icon is visible
     cy.get('[data-name="icon/content/add_24px"]').should('be.visible');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -40,7 +40,7 @@ Cypress.Commands.add('checkAccessibility', (logType) => {
 })
 
 Cypress.Commands.add('goToNextQuestion', () => {
-  //figure out what question we are on and which is next
+  //figure out what question we are on
   cy.get('[data-testid="Question"] h4').then(($h4) => {
     const text = $h4.text();
     const currentQuestion = Number(text.substring(1, text.length - 1));
@@ -53,14 +53,14 @@ Cypress.Commands.add('goToNextQuestion', () => {
 });
 
 Cypress.Commands.add('goToPreviousQuestion', () => {
-  //figure out what question we are on and which is previous
+  //figure out what question we are on
   cy.get('[data-testid="Question"] h4').then(($h4) => {
     const text = $h4.text();
     const currentQuestion = Number(text.substring(1, text.length - 1));
     const prevQuestion = String(currentQuestion - 1);
 
     cy.get('[data-testid="PrevButton"]').click();
-          //assert that we are seeing the previous question
+    //assert that we are seeing the previous question
     cy.get('[data-testid="Question"] h4').should('have.text', `Q${prevQuestion}.`);
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -38,3 +38,29 @@ Cypress.Commands.add('checkAccessibility', (logType) => {
     }
   }, logType)
 })
+
+Cypress.Commands.add('goToNextQuestion', () => {
+  //figure out what question we are on and which is next
+  cy.get('[data-testid="Question"] h4').then(($h4) => {
+    const text = $h4.text();
+    const currentQuestion = Number(text.substring(1, text.length - 1));
+    const nextQuestion = String(currentQuestion + 1);
+
+    cy.contains('Like Me').should('be.visible').click();
+    //assert that we are seeing the next question
+    cy.get('[data-testid="Question"] h4').should('have.text', `Q${nextQuestion}.`)
+  });
+});
+
+Cypress.Commands.add('goToPreviousQuestion', () => {
+  //figure out what question we are on and which is previous
+  cy.get('[data-testid="Question"] h4').then(($h4) => {
+    const text = $h4.text();
+    const currentQuestion = Number(text.substring(1, text.length - 1));
+    const prevQuestion = String(currentQuestion - 1);
+
+    cy.get('[data-testid="PrevButton"]').click();
+          //assert that we are seeing the previous question
+    cy.get('[data-testid="Question"] h4').should('have.text', `Q${prevQuestion}.`);
+  });
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -7,5 +7,15 @@ declare namespace Cypress {
      * A command to check a pages accessibility
     */
     checkAccessibility(log_type: any): void;
+
+    /**
+     * A command to go to next question
+    */
+   goToNextQuestion(): void;
+
+    /**
+     * A command to go to next question
+    */
+   goToPreviousQuestion(): void;
   }
 }


### PR DESCRIPTION
This tests navigating forward and back using the new back button introduced [here](https://github.com/ClimateMind/climatemind-frontend/pull/44)

Added commands for the back and forward navigation functionality to improve readability as this seems like something we might need to do a lot in these tests.