### PR TITLE
CM-142 question styling

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -30,13 +30,10 @@ const styles = makeStyles({
     padding: '1em 0.3em 0 0',
   },
   questionHeader: {
-    // border: '1px solid blue',
     margin: '3em 0',
-    // width: '50vw',
     minHeight: '150px',
   },
   questionHeaderMd: {
-    // border: '1px solid red',
     margin: '3em 0',
     width: '50vw',
     minHeight: '120px',
@@ -73,8 +70,7 @@ const Question: React.FC<Props> = ({
     }, 200);
   };
 
-  // const matchesBreakpoint = useMediaQuery('(min-width:600px)'); 
-  const matchesBreakpoint = useMediaQuery('(min-width:600px)', { noSsr: true });
+  const matchesMd = useMediaQuery('(min-width:600px)', { noSsr: true });
 
   return (
     <>
@@ -82,7 +78,7 @@ const Question: React.FC<Props> = ({
         <FormControl component="fieldset">
           <FormLabel component="legend">
             {/* Question Header - Number and Text */}
-            <Grid item container className={matchesBreakpoint ? classes.questionHeaderMd : classes.questionHeader}>
+            <Grid item container className={matchesMd ? classes.questionHeaderMd : classes.questionHeader}>
               <Grid item xs={3}>
                 <Typography variant="h4" className={classes.questionNumber}>
                   Q{questionNumber}.

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -35,11 +35,11 @@ const styles = makeStyles({
     // width: '50vw',
     minHeight: '150px',
   },
-  questionHeaderLarge: {
+  questionHeaderMd: {
     // border: '1px solid red',
     margin: '3em 0',
     width: '50vw',
-    minHeight: '60px',
+    minHeight: '120px',
   },
   questionNumber: {
     marginRight: '1em',
@@ -73,7 +73,8 @@ const Question: React.FC<Props> = ({
     }, 200);
   };
 
-  const matchesBreakpoint = useMediaQuery('(min-width:600px)');
+  // const matchesBreakpoint = useMediaQuery('(min-width:600px)'); 
+  const matchesBreakpoint = useMediaQuery('(min-width:600px)', { noSsr: true });
 
   return (
     <>
@@ -81,7 +82,7 @@ const Question: React.FC<Props> = ({
         <FormControl component="fieldset">
           <FormLabel component="legend">
             {/* Question Header - Number and Text */}
-            <Grid item container className={matchesBreakpoint ? classes.questionHeaderLarge : classes.questionHeader}>
+            <Grid item container className={matchesBreakpoint ? classes.questionHeaderMd : classes.questionHeader}>
               <Grid item xs={3}>
                 <Typography variant="h4" className={classes.questionNumber}>
                   Q{questionNumber}.

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -33,7 +33,7 @@ const styles = makeStyles({
     // border: '1px solid blue',
     margin: '3em 0',
     // width: '50vw',
-    // minHeight: '60px',
+    minHeight: '150px',
   },
   questionHeaderLarge: {
     // border: '1px solid red',

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -30,8 +30,8 @@ const styles = makeStyles({
     padding: '1em 0.3em 0 0',
   },
   questionHeader: {
-    margin: '3em 0',
-    minHeight: '150px',
+    margin: '1em 0',
+    minHeight: '175px',
   },
   questionHeaderMd: {
     margin: '3em 0',
@@ -78,7 +78,13 @@ const Question: React.FC<Props> = ({
         <FormControl component="fieldset">
           <FormLabel component="legend">
             {/* Question Header - Number and Text */}
-            <Grid item container className={matchesMd ? classes.questionHeaderMd : classes.questionHeader}>
+            <Grid
+              item
+              container
+              className={
+                matchesMd ? classes.questionHeaderMd : classes.questionHeader
+              }
+            >
               <Grid item xs={3}>
                 <Typography variant="h4" className={classes.questionNumber}>
                   Q{questionNumber}.

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -8,6 +8,7 @@ import {
   FormLabel,
   RadioGroup,
 } from '@material-ui/core';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 import GreenRadio from './GreenRadio';
 import { TAnswers } from '../types/types';
 
@@ -29,7 +30,16 @@ const styles = makeStyles({
     padding: '1em 0.3em 0 0',
   },
   questionHeader: {
+    // border: '1px solid blue',
     margin: '3em 0',
+    // width: '50vw',
+    // minHeight: '60px',
+  },
+  questionHeaderLarge: {
+    // border: '1px solid red',
+    margin: '3em 0',
+    width: '50vw',
+    minHeight: '60px',
   },
   questionNumber: {
     marginRight: '1em',
@@ -63,13 +73,15 @@ const Question: React.FC<Props> = ({
     }, 200);
   };
 
+  const matchesBreakpoint = useMediaQuery('(min-width:600px)');
+
   return (
     <>
       <Grid item data-testid="Question">
         <FormControl component="fieldset">
           <FormLabel component="legend">
             {/* Question Header - Number and Text */}
-            <Grid item container className={classes.questionHeader}>
+            <Grid item container className={matchesBreakpoint ? classes.questionHeaderLarge : classes.questionHeader}>
               <Grid item xs={3}>
                 <Typography variant="h4" className={classes.questionNumber}>
                   Q{questionNumber}.

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -15,7 +15,10 @@ const styles = makeStyles({
     overflow: 'hidden',
     padding: '1em 2em',
   },
-  progressDiv: {
+  progressContainer: {
+    minHeight: '45px',
+  },
+  progressBarContainer: {
     height: '12px',
 
     margin: 0,
@@ -71,18 +74,18 @@ const Questionaire: React.FC<{}> = () => {
   }, [setQuestionsToAnswer, questionsToAnswer, questionsAnswered, progress]);
 
   const changeQuestionBackward = useCallback(() => {
-    if(questionsAnswered.length < 1 ){
+    if (questionsAnswered.length < 1) {
       return;
     }
     const updatedAnswered = [...questionsAnswered];
     const updatedToAnswer = [...questionsToAnswer];
     const curr = updatedAnswered.pop();
-    if(curr){
+    if (curr) {
       updatedToAnswer?.push(curr);
       setQuestionsToAnswer(updatedToAnswer);
       setQuestionsAnswered(updatedAnswered);
     }
-    // Set a new currentQuestion to the last question in the list... 
+    // Set a new currentQuestion to the last question in the list...
     setCurrentQuestion(questionsToAnswer[questionsToAnswer.length]);
     setProgress(progress - 1);
   }, [setQuestionsToAnswer, questionsToAnswer, questionsAnswered, progress]);
@@ -159,11 +162,11 @@ const Questionaire: React.FC<{}> = () => {
           {/* Right Gutter */}
         </Grid>
       </Grid>
-      <Grid item container>
+      <Grid item container className={classes.progressContainer}>
         <Grid item xs={false} lg={3}>
           {/* Row 2 -Left Gutter */}
         </Grid>
-        <Grid item xs={12} lg={6} className={classes.progressDiv}>
+        <Grid item xs={12} lg={6} className={classes.progressBarContainer}>
           <LinearProgress
             className={classes.progressBar}
             variant="determinate"
@@ -178,11 +181,12 @@ const Questionaire: React.FC<{}> = () => {
         <Grid item xs={false} lg={3}>
           {/* Row 3 -Left Gutter */}
         </Grid>
-          {progress > 0 && <PrevButton text="Back" clickPrevHandler={changeQuestionBackward}/>}
+        {progress > 0 && (
+          <PrevButton text="Back" clickPrevHandler={changeQuestionBackward} />
+        )}
         <Grid item xs={false} lg={3}>
           {/* Right Gutter */}
         </Grid>
-
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
The content on the questions page moved around when a user changed questions. This pull request fixes that by:
- useMediaQuery hook from Material UI to add different styling for different screen sizes