### PR TITLE
Cm 80 show images for efects fe

### DIFF
--- a/src/api/getPersonalValues.ts
+++ b/src/api/getPersonalValues.ts
@@ -1,11 +1,10 @@
 import axios from 'axios';
 import { TPersonalValues } from '../types/types';
+import { TError } from '../types/Error';
 
-type error = {
-  error: string;
-};
-
-const getPersonalValues = async (sessionId: string): Promise<TPersonalValues | error> => {
+const getPersonalValues = async (
+  sessionId: string
+): Promise<TPersonalValues | TError> => {
   // Set up the call
   const API_HOST =
     process.env.NODE_ENV === 'development'
@@ -16,7 +15,6 @@ const getPersonalValues = async (sessionId: string): Promise<TPersonalValues | e
   try {
     // Call the api
     const response = await axios.get(REQUEST_URL);
-    // const data = response.data.climateEffects;
     const data = response.data;
     return data;
     // Return the response object
@@ -25,6 +23,7 @@ const getPersonalValues = async (sessionId: string): Promise<TPersonalValues | e
     console.error(`Error`, err.message);
     return {
       error: err.message,
+      isError: true,
     };
   }
 };

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -50,6 +50,7 @@ const ClimateFeed: React.FC = () => {
               title={effect.effectTitle}
               shortDescription={effect.effectDescription}
               numberedCards={false}
+              imageUrl={effect.imageUrl}
             />
           ))}
         </Grid>

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -47,6 +47,7 @@ export type TClimateEffect = {
   effectTitle: string;
   effectDescription: string;
   effectScore: number;
+  imageUrl: string;
 };
 
 // export type TPersonalValues = [TPersonalValue];


### PR DESCRIPTION
# Add images to climate effects

- Add imageUrl to climate effect type and image card
- The back returns a default imageurl when the is no image available. In practice just now it means the api always returns the same image url

Testing - In order to test this branch please use the following backend branch [https://github.com/ClimateMind/climatemind-backend/tree/local_db_solution](https://github.com/ClimateMind/climatemind-backend/tree/local_db_solution)

![localhost_3000_(iPhone X) (6)](https://user-images.githubusercontent.com/44759513/97778827-c842af80-1b71-11eb-9001-f7956c1013ef.png)