### PR TITLE
CM-143 Update CSP - Defect Google Tag Manager

### DIFF
--- a/nginx.config
+++ b/nginx.config
@@ -9,7 +9,7 @@ server {
         try_files $$uri /index.html;
     }
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://*.typekit.net; img-src 'self' data:; font-src 'self' https://*.typekit.net data:; connect-src 'self' https://*.okta.com https://app-backend-prod-001.azurewebsites.net;";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.googletagmanager.com/ 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://*.typekit.net; img-src * 'self' data:; font-src 'self' https://*.typekit.net data:; connect-src 'self' https://*.okta.com https://app-backend-prod-001.azurewebsites.net;";
     add_header Referrer-Policy "no-referrer, strict-origin-when-cross-origin";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
Update the CSP to allow access to google tag manager and images from any src. We may need to go back and be more restrictive in the future. 

Tested agains docker build to replicate production and seems to be working although as the Tag Manager Container has [not been published yet getting a 404 back form google. ](https://support.google.com/tagmanager/thread/10386291?hl=en)

<img width="1735" alt="Screenshot 2020-11-01 at 11 27 09" src="https://user-images.githubusercontent.com/44759513/97801556-85e2a680-1c35-11eb-9d86-19627e7e58b4.png">
<img width="1734" alt="Screenshot 2020-11-01 at 11 26 54" src="https://user-images.githubusercontent.com/44759513/97801558-88450080-1c35-11eb-8f91-0636ecf6d195.png">
