### PR TITLE
CM-187 Percy snapshots of error pages

### DIFF
--- a/cypress/integration/errorpages.spec.ts
+++ b/cypress/integration/errorpages.spec.ts
@@ -1,0 +1,23 @@
+/// <reference types="cypress" />
+
+import { terminalLog } from '../support/helpers.ts';
+
+describe('Error pages load and look correct', () => {
+  it('can visit 404 error page', () => {
+    cy.visit('/fakepage');
+    cy.contains('Well this is awkward').should('be.visible');
+    cy.checkAccessibility(terminalLog);
+    cy.percySnapshot('404 Error Page');
+
+    cy.contains('a', 'Homepage').should('have.attr', 'href', '/');
+    cy.contains('Go to homepage').click();
+    cy.url().should('equal', Cypress.config().baseUrl);
+  });
+
+  it('can visit 500 error page', () => {
+    cy.visit('/questionnaire');
+    cy.contains('It’s broken…').should('be.visible');
+    cy.checkAccessibility(terminalLog);
+    cy.percySnapshot('500 Error Page');
+  });
+});

--- a/cypress/integration/errorpages.spec.ts
+++ b/cypress/integration/errorpages.spec.ts
@@ -11,7 +11,7 @@ describe('Error pages load and look correct', () => {
 
     cy.contains('a', 'Homepage').should('have.attr', 'href', '/');
     cy.contains('Go to homepage').click();
-    cy.url().should('equal', Cypress.config().baseUrl);
+    cy.url().should('equal', `${Cypress.config().baseUrl}/`);
   });
 
   it('can visit 500 error page', () => {

--- a/src/pages/Error404.tsx
+++ b/src/pages/Error404.tsx
@@ -71,7 +71,7 @@ const Error500: React.FC<{}> = () => {
             disableElevation
             onClick={() => push('/')}
           >
-            Go to home page
+            Go to homepage
           </Button>
 
           <Button


### PR DESCRIPTION
Adds Percy snapshots of the error pages, so they can't be accidentally broken by a css change somewhere else. 