### PR TITLE
CM-218 user not nav to top of clim feed 2

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
-  {
-  "short_name": "CM",
+{
+  "short_name": "Climate Mind",
   "name": "Climate Mind",
   "icons": [
     {

--- a/src/components/CMCard.tsx
+++ b/src/components/CMCard.tsx
@@ -13,13 +13,14 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      margin: '1em 1em',
-      // height: '100%',
+      margin: '1em 0',
+      width: '100%',
     },
     card: {
       backgroundColor: '#fff',
       height: '100%',
-      minWidth: '343px',
+      width: '100%',
+      // minWidth: '343px',
     },
     cardHeader: {
       paddingTop: '8px',
@@ -63,15 +64,8 @@ const CMCard: React.FC<CMCardProps> = ({
   const classes = useStyles();
 
   return (
-    <Grid
-      item
-      sm={12}
-      lg={12}
-      container
-      className={classes.root}
-      data-testid="CMCard"
-    >
-      <Card className={classes.card} style={{width:'95%'}}>
+    <Grid item sm={12} lg={12} className={classes.root} data-testid="CMCard">
+      <Card className={classes.card}>
         <CardContent>
           <Typography
             className={classes.title}
@@ -107,7 +101,7 @@ const CMCard: React.FC<CMCardProps> = ({
             {shortDescription}
           </Typography>
         </CardContent>
-        {footer} 
+        {footer}
       </Card>
     </Grid>
   );

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -2,16 +2,22 @@ import React from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 import Div100vh from 'react-div-100vh';
 
-type PageWrapperProps = {
-  bgColor: string;
+type WrapperProps = {
+  bgColor?: string;
+  scroll?: boolean;
   children?: React.ReactNode;
 };
 
-const PageWrapper: React.FC<PageWrapperProps> = ({ children, bgColor }) => {
+const PageWrapper: React.FC<WrapperProps> = ({
+  children,
+  bgColor,
+  scroll = false,
+}) => {
   const styles = makeStyles({
     root: {
-      backgroundColor: bgColor,
-      overflow: 'hidden',
+      backgroundColor: bgColor ? bgColor : 'inherit',
+      overflow: scroll ? 'auto' : 'hidden',
+      minWidth: '375px',
     },
     outerGrid: {
       padding: '3em 1em',
@@ -23,20 +29,22 @@ const PageWrapper: React.FC<PageWrapperProps> = ({ children, bgColor }) => {
 
   return (
     // The Div100Vh element ensures that the outer grid takes up full screen height but avoids content behind the top and bottom bars on iphone by finding the innerHeight of the viewport
-    <Div100vh className={classes.root}>
-      <Grid container direction="row" className={classes.outerGrid}>
-        <Grid
-          item
-          container
-          direction="column"
-          alignItems="center"
-          justify="space-between"
-          wrap="nowrap"
-        >
-          {children}
+    <>
+      <Div100vh className={classes.root}>
+        <Grid container direction="row" className={classes.outerGrid}>
+          <Grid
+            item
+            container
+            direction="column"
+            alignItems="center"
+            justify="space-between"
+            wrap="nowrap"
+          >
+            {children}
+          </Grid>
         </Grid>
-      </Grid>
-    </Div100vh>
+      </Div100vh>
+    </>
   );
 };
 

--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 
-type WrapperProps = {
+export type WrapperProps = {
   bgColor?: string;
   fullHeight?: boolean;
   children?: React.ReactNode;

--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Grid, makeStyles } from '@material-ui/core';
+
+type WrapperProps = {
+  bgColor?: string;
+  fullHeight?: boolean;
+  children?: React.ReactNode;
+};
+
+const Wrapper: React.FC<WrapperProps> = ({
+  children,
+  bgColor,
+  fullHeight = false,
+}) => {
+  const styles = makeStyles({
+    root: {
+      backgroundColor: bgColor ? bgColor : 'inherit',
+      height: fullHeight ? '100vh' : 'auto',
+      minWidth: '375px',
+    },
+    outerGrid: {
+      padding: '3em 1em',
+      height: '100%',
+    },
+  });
+
+  const classes = styles();
+
+  return (
+    <div className={classes.root}>
+      <Grid container direction="row" className={classes.outerGrid}>
+        <Grid
+          item
+          container
+          direction="column"
+          alignItems="center"
+          justify="space-between"
+          wrap="nowrap"
+        >
+          {children}
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export default Wrapper;

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -31,8 +31,6 @@ const ClimateFeed: React.FC = () => {
   }
   return (
     <PageWrapper bgColor="#70D7CC" scroll={true}>
-      {/* Toolbar required to prevent content disap behind the app bar*/}
-      <Toolbar variant="dense" />
       <Grid
         container
         className={classes.root}

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Grid, makeStyles, Toolbar } from '@material-ui/core';
 import Loader from '../components/Loader';
 import CMCard from '../components/CMCard';
+import PageWrapper from '../components/PageWrapper';
 import CMCardOverlay from '../components/CMCardOverlay';
 
 import { useClimateFeed } from '../hooks/useClimateFeed';
@@ -11,6 +12,10 @@ const useStyles = makeStyles({
     flexGrow: 1,
     backgroundColor: '#70D7CC',
     minHeight: '100vh',
+    padding: 0,
+  },
+  feedContainer: {
+    padding: 0,
   },
   typography: {
     textAlign: 'center',
@@ -25,7 +30,7 @@ const ClimateFeed: React.FC = () => {
     return <Loader />;
   }
   return (
-    <>
+    <PageWrapper bgColor="#70D7CC" scroll={true}>
       {/* Toolbar required to prevent content disap behind the app bar*/}
       <Toolbar variant="dense" />
       <Grid
@@ -34,7 +39,7 @@ const ClimateFeed: React.FC = () => {
         data-testid="ClimateFeed"
         justify="space-around"
       >
-        <Grid item sm={12} lg={12} container>
+        <Grid item sm={12} lg={12} container className={classes.feedContainer}>
           {climateFeed.map((effect, i) => (
             <CMCard
               key={`value-${i}`}
@@ -54,7 +59,7 @@ const ClimateFeed: React.FC = () => {
           ))}
         </Grid>
       </Grid>
-    </>
+    </PageWrapper>
   );
 };
 

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, makeStyles, Toolbar } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import Loader from '../components/Loader';
 import CMCard from '../components/CMCard';
 import PageWrapper from '../components/PageWrapper';

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -65,78 +65,82 @@ const PersonalValues: React.FC = () => {
       data-testid="PersonalValues"
       justify="space-around"
     >
-      <Wrapper bgColor="#B8F4FC">
-        <Grid item sm={false} lg={4}>
-          {/* left gutter */}
-        </Grid>
-
-        <Grid
-          item
-          sm={12}
-          lg={4}
-          container
-          direction="row"
-          justify="center"
-          alignItems="center"
-        >
-          <Grid item>
-            <Box mt={2} mb={4} mx={2}>
-              <Grid container direction="row" alignItems="center" spacing={5}>
-                <Grid item xs={3}>
-                  <Logo width="76" data-testid="climate-mind-logo" />
-                </Grid>
-                <Grid item xs={9}>
-                  <Typography variant="h4">
-                    This is your Climate Personality
-                  </Typography>
-                </Grid>
-              </Grid>
-            </Box>
+      {/* Personal Values Section */}
+      <section>
+        <Wrapper bgColor="#B8F4FC">
+          <Grid item sm={false} lg={4}>
+            {/* left gutter */}
           </Grid>
 
-          <Grid item sm={12} lg={12} container>
-            {climatePersonality.personalValues &&
-              climatePersonality.personalValues.map((value, i) => (
-                <CMCard
-                  key={`value-${i}`}
-                  index={i}
-                  title={value.name}
-                  shortDescription={value.shortDescription}
-                  imageUrl={
-                    process.env.PUBLIC_URL + `personality/${value.id}.gif`
-                  }
-                  footer={
-                    <CMCardFoldout
-                      description={value.description}
-                    ></CMCardFoldout>
-                  }
-                />
-              ))}
-          </Grid>
-
-          <Grid item sm={12} lg={6} container justify="center">
-            <Box mt={6} mb={4} px={2} textAlign="center">
-              <Typography variant="h6">
-                Climate Personality not quite right?
-              </Typography>
-              <Box mt={4}>
-                <Button onClick={handleRetakeQuiz} variant="text">
-                  Retake the Quiz
-                </Button>
+          <Grid
+            item
+            sm={12}
+            lg={4}
+            container
+            direction="row"
+            justify="center"
+            alignItems="center"
+          >
+            <Grid item>
+              <Box mt={2} mb={4} mx={2}>
+                <Grid container direction="row" alignItems="center" spacing={5}>
+                  <Grid item xs={3}>
+                    <Logo width="76" data-testid="climate-mind-logo" />
+                  </Grid>
+                  <Grid item xs={9}>
+                    <Typography variant="h4">
+                      This is your Climate Personality
+                    </Typography>
+                  </Grid>
+                </Grid>
               </Box>
-            </Box>
-            <Box mt={5} mb={3}>
-              <ArrowDown />
-            </Box>
+            </Grid>
+
+            <Grid item sm={12} lg={12} container>
+              {climatePersonality.personalValues &&
+                climatePersonality.personalValues.map((value, i) => (
+                  <CMCard
+                    key={`value-${i}`}
+                    index={i}
+                    title={value.name}
+                    shortDescription={value.shortDescription}
+                    imageUrl={
+                      process.env.PUBLIC_URL + `personality/${value.id}.gif`
+                    }
+                    footer={
+                      <CMCardFoldout
+                        description={value.description}
+                      ></CMCardFoldout>
+                    }
+                  />
+                ))}
+            </Grid>
+
+            <Grid item sm={12} lg={6} container justify="center">
+              <Box mt={6} mb={4} px={2} textAlign="center">
+                <Typography variant="h6">
+                  Climate Personality not quite right?
+                </Typography>
+                <Box mt={4}>
+                  <Button onClick={handleRetakeQuiz} variant="text">
+                    Retake the Quiz
+                  </Button>
+                </Box>
+              </Box>
+              <Box mt={5} mb={3}>
+                <ArrowDown />
+              </Box>
+            </Grid>
           </Grid>
-        </Grid>
 
-        <Grid item sm={false} lg={4}>
-          {/* right gutter */}
-        </Grid>
-      </Wrapper>
+          <Grid item sm={false} lg={4}>
+            {/* right gutter */}
+          </Grid>
+        </Wrapper>
+      </section>
 
-      <div className={classes.callToActionSection}>
+      {/* Call to action section */}
+      <section>
         <Wrapper bgColor="#FAFF7E" fullHeight={true}>
           <Grid item sm={false} lg={4}>
             {/* left gutter */}
@@ -193,7 +197,7 @@ const PersonalValues: React.FC = () => {
             {/* right gutter */}
           </Grid>
         </Wrapper>
-      </div>
+      </section>
     </Grid>
   );
 };

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -66,19 +66,88 @@ const PersonalValues: React.FC = () => {
     return <Error500 />;
   }
   return (
-    <>
-      <Toolbar variant="dense" />
-      <Grid
-        container
-        className={classes.root}
-        data-testid="PersonalValues"
-        justify="space-around"
-      >
-        <Wrapper bgColor="#B8F4FC">
+    <Grid
+      container
+      className={classes.root}
+      data-testid="PersonalValues"
+      justify="space-around"
+    >
+      <Wrapper bgColor="#B8F4FC">
+        <Grid item sm={false} lg={4}>
+          {/* left gutter */}
+        </Grid>
+
+        <Grid
+          item
+          sm={12}
+          lg={4}
+          container
+          direction="row"
+          justify="center"
+          alignItems="center"
+        >
+          <Grid item>
+            <Box mt={2} mb={4} mx={2}>
+              <Grid container direction="row" alignItems="center" spacing={5}>
+                <Grid item xs={3}>
+                  <Logo width="76" data-testid="climate-mind-logo" />
+                </Grid>
+                <Grid item xs={9}>
+                  <Typography variant="h4">
+                    This is your Climate Personality
+                  </Typography>
+                </Grid>
+              </Grid>
+            </Box>
+          </Grid>
+
+          <Grid item sm={12} lg={12} container>
+            {climatePersonality.personalValues &&
+              climatePersonality.personalValues.map((value, i) => (
+                <CMCard
+                  key={`value-${i}`}
+                  index={i}
+                  title={value.name}
+                  shortDescription={value.shortDescription}
+                  imageUrl={
+                    process.env.PUBLIC_URL + `personality/${value.id}.gif`
+                  }
+                  footer={
+                    <CMCardFoldout
+                      description={value.description}
+                    ></CMCardFoldout>
+                  }
+                />
+              ))}
+          </Grid>
+
+          <Grid item sm={12} lg={6} container justify="center">
+            <Box mt={6} mb={4} px={2} textAlign="center">
+              <Typography variant="h6">
+                Climate Personality not quite right?
+              </Typography>
+              <Box mt={4}>
+                <Button onClick={handleRetakeQuiz} variant="text">
+                  Retake the Quiz
+                </Button>
+              </Box>
+            </Box>
+            <Box mt={5} mb={3}>
+              <ArrowDown />
+            </Box>
+          </Grid>
+        </Grid>
+
+        <Grid item sm={false} lg={4}>
+          {/* right gutter */}
+        </Grid>
+      </Wrapper>
+
+      <div className={classes.callToActionSection}>
+        <Wrapper bgColor="#FAFF7E" fullHeight={true}>
           <Grid item sm={false} lg={4}>
             {/* left gutter */}
           </Grid>
-
           <Grid
             item
             sm={12}
@@ -89,53 +158,40 @@ const PersonalValues: React.FC = () => {
             alignItems="center"
           >
             <Grid item>
-              <Box mt={2} mb={4} mx={2}>
+              <Box mt={2} mb={4} px={2}>
                 <Grid container direction="row" alignItems="center" spacing={5}>
                   <Grid item xs={3}>
                     <Logo width="76" data-testid="climate-mind-logo" />
                   </Grid>
                   <Grid item xs={9}>
                     <Typography variant="h4">
-                      This is your Climate Personality
+                      Ready to dive into Climate Mind?
                     </Typography>
                   </Grid>
                 </Grid>
               </Box>
             </Grid>
 
-            <Grid item sm={12} lg={12} container>
-              {climatePersonality.personalValues &&
-                climatePersonality.personalValues.map((value, i) => (
-                  <CMCard
-                    key={`value-${i}`}
-                    index={i}
-                    title={value.name}
-                    shortDescription={value.shortDescription}
-                    imageUrl={
-                      process.env.PUBLIC_URL + `personality/${value.id}.gif`
-                    }
-                    footer={
-                      <CMCardFoldout
-                        description={value.description}
-                      ></CMCardFoldout>
-                    }
-                  />
-                ))}
+            <Grid item sm={12} lg={6}>
+              <Box mt={2} mb={3} px={5} textAlign="center">
+                <Typography variant="h6">
+                  You are about to see how you can take action against climate
+                  change
+                </Typography>
+              </Box>
             </Grid>
 
-            <Grid item sm={12} lg={6} container justify="center">
-              <Box mt={6} mb={4} px={2} textAlign="center">
-                <Typography variant="h6">
-                  Climate Personality not quite right?
-                </Typography>
-                <Box mt={4}>
-                  <Button onClick={handleRetakeQuiz} variant="text">
-                    Retake the Quiz
-                  </Button>
-                </Box>
-              </Box>
-              <Box mt={5} mb={3}>
-                <ArrowDown />
+            <Grid item container justify="center">
+              <Box mt={4} mb={8}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  fullWidth
+                  disableElevation
+                  onClick={() => push(ROUTES.ROUTE_FEED)}
+                >
+                  Yes, I’m ready!
+                </Button>
               </Box>
             </Grid>
           </Grid>
@@ -144,72 +200,8 @@ const PersonalValues: React.FC = () => {
             {/* right gutter */}
           </Grid>
         </Wrapper>
-
-        <div className={classes.callToActionSection}>
-          <Wrapper bgColor="#FAFF7E" fullHeight={true}>
-            <Grid item sm={false} lg={4}>
-              {/* left gutter */}
-            </Grid>
-            <Grid
-              item
-              sm={12}
-              lg={4}
-              container
-              direction="row"
-              justify="center"
-              alignItems="center"
-            >
-              <Grid item>
-                <Box mt={2} mb={4} px={2}>
-                  <Grid
-                    container
-                    direction="row"
-                    alignItems="center"
-                    spacing={5}
-                  >
-                    <Grid item xs={3}>
-                      <Logo width="76" data-testid="climate-mind-logo" />
-                    </Grid>
-                    <Grid item xs={9}>
-                      <Typography variant="h4">
-                        Ready to dive into Climate Mind?
-                      </Typography>
-                    </Grid>
-                  </Grid>
-                </Box>
-              </Grid>
-
-              <Grid item sm={12} lg={6}>
-                <Box mt={2} mb={3} px={5} textAlign="center">
-                  <Typography variant="h6">
-                    You are about to see how you can take action against climate
-                    change
-                  </Typography>
-                </Box>
-              </Grid>
-
-              <Grid item container justify="center">
-                <Box mt={4} mb={8}>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    fullWidth
-                    disableElevation
-                    onClick={() => push(ROUTES.ROUTE_FEED)}
-                  >
-                    Yes, I’m ready!
-                  </Button>
-                </Box>
-              </Grid>
-            </Grid>
-
-            <Grid item sm={false} lg={4}>
-              {/* right gutter */}
-            </Grid>
-          </Wrapper>
-        </div>
-      </Grid>
-    </>
+      </div>
+    </Grid>
   );
 };
 

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -18,15 +18,14 @@ import Error500 from '../pages/Error500';
 import { useClimatePersonality } from '../hooks/useClimatePersonality';
 import { ReactComponent as ArrowDown } from '../assets/icon-arrow-down.svg';
 import CMCardFoldout from '../components/CMCardFoldout';
+import Wrapper from '../components/Wrapper';
 
 const styles = makeStyles({
   root: {
     flexGrow: 1,
-    backgroundColor: '#B8F4FC',
     minHeight: '100vh',
   },
-  section: {
-    backgroundColor: '#FAFF7E',
+  callToActionSection: {
     minHeight: '100vh',
   },
   typography: {
@@ -75,126 +74,140 @@ const PersonalValues: React.FC = () => {
         data-testid="PersonalValues"
         justify="space-around"
       >
-        <Grid item sm={false} lg={4}>
-          {/* left gutter */}
-        </Grid>
-
-        <Grid
-          item
-          sm={12}
-          lg={4}
-          container
-          direction="row"
-          justify="center"
-          alignItems="center"
-        >
-          <Grid item>
-            <Box mt={2} mb={4} mx={2}>
-              <Grid container direction="row" alignItems="center" spacing={5}>
-                <Grid item xs={3}>
-                  <Logo width="76" data-testid="climate-mind-logo" />
-                </Grid>
-                <Grid item xs={9}>
-                  <Typography variant="h4">
-                    This is your Climate Personality
-                  </Typography>
-                </Grid>
-              </Grid>
-            </Box>
+        <Wrapper bgColor="#B8F4FC">
+          <Grid item sm={false} lg={4}>
+            {/* left gutter */}
           </Grid>
 
-          <Grid item sm={12} lg={12} container>
-            {climatePersonality.personalValues &&
-              climatePersonality.personalValues.map((value, i) => (
-                <CMCard
-                  key={`value-${i}`}
-                  index={i}
-                  title={value.name}
-                  shortDescription={value.shortDescription}
-                  imageUrl={
-                    process.env.PUBLIC_URL + `personality/${value.id}.gif`
-                  }
-                  footer={<CMCardFoldout description={value.description}></CMCardFoldout>}
-                />
-              ))}
-          </Grid>
-
-          <Grid item sm={12} lg={6} container justify="center">
-            <Box mt={6} mb={4} px={2} textAlign="center">
-              <Typography variant="h6">
-                Climate Personality not quite right?
-              </Typography>
-              <Box mt={4}>
-                <Button onClick={handleRetakeQuiz} variant="text">
-                  Retake the Quiz
-                </Button>
+          <Grid
+            item
+            sm={12}
+            lg={4}
+            container
+            direction="row"
+            justify="center"
+            alignItems="center"
+          >
+            <Grid item>
+              <Box mt={2} mb={4} mx={2}>
+                <Grid container direction="row" alignItems="center" spacing={5}>
+                  <Grid item xs={3}>
+                    <Logo width="76" data-testid="climate-mind-logo" />
+                  </Grid>
+                  <Grid item xs={9}>
+                    <Typography variant="h4">
+                      This is your Climate Personality
+                    </Typography>
+                  </Grid>
+                </Grid>
               </Box>
-            </Box>
-            <Box mt={5} mb={3}>
-              <ArrowDown />
-            </Box>
+            </Grid>
+
+            <Grid item sm={12} lg={12} container>
+              {climatePersonality.personalValues &&
+                climatePersonality.personalValues.map((value, i) => (
+                  <CMCard
+                    key={`value-${i}`}
+                    index={i}
+                    title={value.name}
+                    shortDescription={value.shortDescription}
+                    imageUrl={
+                      process.env.PUBLIC_URL + `personality/${value.id}.gif`
+                    }
+                    footer={
+                      <CMCardFoldout
+                        description={value.description}
+                      ></CMCardFoldout>
+                    }
+                  />
+                ))}
+            </Grid>
+
+            <Grid item sm={12} lg={6} container justify="center">
+              <Box mt={6} mb={4} px={2} textAlign="center">
+                <Typography variant="h6">
+                  Climate Personality not quite right?
+                </Typography>
+                <Box mt={4}>
+                  <Button onClick={handleRetakeQuiz} variant="text">
+                    Retake the Quiz
+                  </Button>
+                </Box>
+              </Box>
+              <Box mt={5} mb={3}>
+                <ArrowDown />
+              </Box>
+            </Grid>
           </Grid>
-        </Grid>
 
-        <Grid item sm={false} lg={4}>
-          {/* right gutter */}
-        </Grid>
+          <Grid item sm={false} lg={4}>
+            {/* right gutter */}
+          </Grid>
+        </Wrapper>
 
-        <Grid item sm={false} lg={4} className={classes.section}>
-          {/* left gutter */}
-        </Grid>
-        <Grid
-          item
-          sm={12}
-          lg={4}
-          container
-          className={classes.section}
-          direction="row"
-          justify="center"
-          alignItems="center"
-        >
-          <Grid item>
-            <Box mt={2} mb={4} px={2}>
-              <Grid container direction="row" alignItems="center" spacing={5}>
-                <Grid item xs={3}>
-                  <Logo width="76" data-testid="climate-mind-logo" />
-                </Grid>
-                <Grid item xs={9}>
-                  <Typography variant="h4">
-                    Ready to dive into Climate Mind?
-                  </Typography>
-                </Grid>
+        <div className={classes.callToActionSection}>
+          <Wrapper bgColor="#FAFF7E" fullHeight={true}>
+            <Grid item sm={false} lg={4}>
+              {/* left gutter */}
+            </Grid>
+            <Grid
+              item
+              sm={12}
+              lg={4}
+              container
+              direction="row"
+              justify="center"
+              alignItems="center"
+            >
+              <Grid item>
+                <Box mt={2} mb={4} px={2}>
+                  <Grid
+                    container
+                    direction="row"
+                    alignItems="center"
+                    spacing={5}
+                  >
+                    <Grid item xs={3}>
+                      <Logo width="76" data-testid="climate-mind-logo" />
+                    </Grid>
+                    <Grid item xs={9}>
+                      <Typography variant="h4">
+                        Ready to dive into Climate Mind?
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                </Box>
               </Grid>
-            </Box>
-          </Grid>
 
-          <Grid item sm={12} lg={6}>
-            <Box mt={2} mb={3} px={5} textAlign="center">
-              <Typography variant="h6">
-                You are about to see how you can take action against climate
-                change
-              </Typography>
-            </Box>
-          </Grid>
+              <Grid item sm={12} lg={6}>
+                <Box mt={2} mb={3} px={5} textAlign="center">
+                  <Typography variant="h6">
+                    You are about to see how you can take action against climate
+                    change
+                  </Typography>
+                </Box>
+              </Grid>
 
-          <Grid item container justify="center">
-            <Box mt={4} mb={8}>
-              <Button
-                variant="contained"
-                color="primary"
-                fullWidth
-                disableElevation
-                onClick={() => push(ROUTES.ROUTE_FEED)}
-              >
-                Yes, I’m ready!
-              </Button>
-            </Box>
-          </Grid>
-        </Grid>
+              <Grid item container justify="center">
+                <Box mt={4} mb={8}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    fullWidth
+                    disableElevation
+                    onClick={() => push(ROUTES.ROUTE_FEED)}
+                  >
+                    Yes, I’m ready!
+                  </Button>
+                </Box>
+              </Grid>
+            </Grid>
 
-        <Grid item sm={false} lg={4} className={classes.section}>
-          {/* right gutter */}
-        </Grid>
+            <Grid item sm={false} lg={4}>
+              {/* right gutter */}
+            </Grid>
+          </Wrapper>
+        </div>
       </Grid>
     </>
   );

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
-import {
-  Typography,
-  Button,
-  Grid,
-  makeStyles,
-  Box,
-  Toolbar,
-} from '@material-ui/core';
+import { Typography, Button, Grid, makeStyles, Box } from '@material-ui/core';
 import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import Loader from '../components/Loader';
 import ROUTES from '../components/Router/RouteConfig';

--- a/src/stories/components/Wrapper.stories.tsx
+++ b/src/stories/components/Wrapper.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Wrapper, { WrapperProps } from '../../components/Wrapper';
+
+export default {
+  title: 'ClimateMind/components/Wrapper',
+  component: Wrapper,
+} as Meta;
+
+const Template: Story<WrapperProps> = (args) => <Wrapper {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  children: <p>Occaecat ad exercitation culpa amet tempor.</p>,
+};
+
+export const BackGroundColor = Template.bind({});
+BackGroundColor.args = {
+  bgColor: '#39F5AD',
+  children: <p>Occaecat ad exercitation culpa amet tempor.</p>,
+};
+
+export const FullHeight = Template.bind({});
+FullHeight.args = {
+  bgColor: '#39F5AD',
+  fullHeight: true,
+  children: <p>Occaecat ad exercitation culpa amet tempor.</p>,
+};

--- a/src/stories/pages/ClimateFeed.stories.tsx
+++ b/src/stories/pages/ClimateFeed.stories.tsx
@@ -5,6 +5,7 @@ import { Grid, makeStyles, Toolbar } from '@material-ui/core';
 import Loader from '../../components/Loader';
 import CMCard from '../../components/CMCard';
 import CMCardOverlay from '../../components/CMCardOverlay';
+import Wrapper from '../../components/Wrapper';
 import AppBar from '../../components/AppBar/AppBar';
 
 // import ClimateFeed from '../../pages/ClimateFeed';
@@ -13,7 +14,7 @@ import AppBar from '../../components/AppBar/AppBar';
 const styles = makeStyles({
   root: {
     flexGrow: 1,
-    backgroundColor: '#70D7CC',
+
     minHeight: '100vh',
   },
   typography: {
@@ -48,39 +49,41 @@ const ClimateFeed: React.FC = () => {
   }
   return (
     <>
-      {/* Toolbar required to prevent content disap behind the app bar*/}
-      <Grid
-        container
-        className={classes.root}
-        data-testid="ClimateFeed"
-        justify="space-around"
-      >
-        <AppBar />
-        <Toolbar variant="dense" />
-        <Grid item sm={12} lg={12} container>
-          {climateFeed.map((effect, i) => (
-            <CMCard
-              key={`value-${i}`}
-              index={i}
-              title={effect.effectTitle}
-              shortDescription={effect.effectDescription}
-              numberedCards={false}
-              imageUrl={effect.imageUrl}
-              footer={
-                <CMCardOverlay
-                  title={effect.effectTitle}
-                  imageUrl={effect.imageUrl}
-                  shortDescription={effect.effectDescription}
-                />
-              }
-            />
-          ))}
-        </Grid>
+      <Wrapper bgColor="#70D7CC">
+        <Grid
+          container
+          className={classes.root}
+          data-testid="ClimateFeed"
+          justify="space-around"
+        >
+          <AppBar />
+          {/* Toolbar required to prevent content disap behind the app bar*/}
+          <Toolbar variant="dense" />
+          <Grid item sm={12} lg={12} container>
+            {climateFeed.map((effect, i) => (
+              <CMCard
+                key={`value-${i}`}
+                index={i}
+                title={effect.effectTitle}
+                shortDescription={effect.effectDescription}
+                numberedCards={false}
+                imageUrl={effect.imageUrl}
+                footer={
+                  <CMCardOverlay
+                    title={effect.effectTitle}
+                    imageUrl={effect.imageUrl}
+                    shortDescription={effect.effectDescription}
+                  />
+                }
+              />
+            ))}
+          </Grid>
 
-        <Grid item sm={false} lg={4}>
-          {/* right gutter */}
+          <Grid item sm={false} lg={4}>
+            {/* right gutter */}
+          </Grid>
         </Grid>
-      </Grid>
+      </Wrapper>
     </>
   );
 };

--- a/src/stories/pages/ClimateFeed.stories.tsx
+++ b/src/stories/pages/ClimateFeed.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
-import { Grid, makeStyles, Toolbar } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import Loader from '../../components/Loader';
 import CMCard from '../../components/CMCard';
 import CMCardOverlay from '../../components/CMCardOverlay';
@@ -14,7 +14,6 @@ import AppBar from '../../components/AppBar/AppBar';
 const styles = makeStyles({
   root: {
     flexGrow: 1,
-
     minHeight: '100vh',
   },
   typography: {

--- a/src/stories/pages/ClimateFeed.stories.tsx
+++ b/src/stories/pages/ClimateFeed.stories.tsx
@@ -57,8 +57,7 @@ const ClimateFeed: React.FC = () => {
           justify="space-around"
         >
           <AppBar />
-          {/* Toolbar required to prevent content disap behind the app bar*/}
-          <Toolbar variant="dense" />
+
           <Grid item sm={12} lg={12} container>
             {climateFeed.map((effect, i) => (
               <CMCard


### PR DESCRIPTION
# Bug 🐞 [User doesn't navigate to the top of the climate feed](https://climatemind.atlassian.net/browse/CM-218)

## Details
flexbox layout issues cause in user to appear to navigate to the bottom of the climate feed. 
- Set up **wrapper component** to allow us to wrap pages and sections in a flexbox grid.
 -- Wrapper centers the child components in the middle of the page
 -- Ability to accept backgroundColor and fullHeight props.
- Wrap Climate feed in wrapper
- Wrap Personal Values Feed (each section) in wrapper
- Add wrapper component to story book

<img width="1101" alt="Screenshot 2020-11-28 at 11 18 49" src="https://user-images.githubusercontent.com/44759513/100514418-6c694780-316c-11eb-9bfd-fd6327e4d18e.png">
<img width="445" alt="Screenshot 2020-11-27 at 22 03 26" src="https://user-images.githubusercontent.com/44759513/100514419-712dfb80-316c-11eb-8c88-17fa6c7852b1.png">

