### PR TITLE
Cm 220 effect cards show correct descriptions

### DIFF
--- a/src/components/CMCard.tsx
+++ b/src/components/CMCard.tsx
@@ -101,16 +101,18 @@ const CMCard: React.FC<CMCardProps> = ({
 
         <CardContent>
           <Typography variant="body1" component="p">
-            {/* TODO - Make this show conditionally when we have long descriptions */}
             {shortDescription}
           </Typography>
         </CardContent>
 
-        {footer} 
+        {footer}
         {actionHeadline && (
-          <ActionHeadline actionHeadline={actionHeadline} icon={<EmojiObjectsIcon fontSize="default"/>} />
+          <ActionHeadline
+            actionHeadline={actionHeadline}
+            icon={<EmojiObjectsIcon fontSize="default" />}
+          />
         )}
-        </Card>
+      </Card>
     </Grid>
   );
 };

--- a/src/components/CMCardFoldout.tsx
+++ b/src/components/CMCardFoldout.tsx
@@ -26,14 +26,13 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface CMCardFoldoutProps {
   description?: string;
-  
+  shortDescription?: string;
 }
 
 const CMCardFoldout: React.FC<CMCardFoldoutProps> = ({
-  
   description,
+  shortDescription,
 }: CMCardFoldoutProps) => {
-
   const classes = useStyles();
 
   const [showMore, setShowMore] = React.useState(false);
@@ -42,35 +41,42 @@ const CMCardFoldout: React.FC<CMCardFoldoutProps> = ({
     setShowMore(!showMore);
   };
 
-
   return (
     <>
       <Collapse in={showMore} timeout="auto" unmountOnExit>
         <CardContent>
-        {description && (
+          {/* Show short desciption if ther is one */}
+          {shortDescription && (
             <Typography variant="body1" component="p">
-            {description}
+              {shortDescription}
             </Typography>
-        )}
+          )}
+          {/* Show Long desciption if ther is one */}
+          {description && (
+            <Typography variant="body1" component="p">
+              {description}
+            </Typography>
+          )}
         </CardContent>
-      </Collapse>   
+      </Collapse>
 
       <CardActions>
-      <Button
-        className={classes.more}
-        variant="text"
-        onClick={handleShowMoreClick}
-        data-testid="CMCardMore"
-      >
-        {showMore ? 'LESS' : 'MORE'}
-      </Button>
+        <Button
+          className={classes.more}
+          variant="text"
+          onClick={handleShowMoreClick}
+          data-testid="CMCardMore"
+        >
+          {showMore ? 'LESS' : 'MORE'}
+        </Button>
       </CardActions>
     </>
   );
 };
 
 CMCardFoldout.defaultProps = {
-  description: 'Cupidatat aute Lorem aliquip fugiat reprehenderit pariatur sunt est incididunt mollit reprehenderit tempor irure excepteur. Do labore aliquip reprehenderit consectetur dolore mollit Lorem fugiat exercitation magna elit aliquip commodo commodo. Dolor adipisicing exercitation incididunt irure dolor ad aute ad commodo mollit proident. Ullamco sunt voluptate sunt quis.',
+  description:
+    'Cupidatat aute Lorem aliquip fugiat reprehenderit pariatur sunt est incididunt mollit reprehenderit tempor irure excepteur. Do labore aliquip reprehenderit consectetur dolore mollit Lorem fugiat exercitation magna elit aliquip commodo commodo. Dolor adipisicing exercitation incididunt irure dolor ad aute ad commodo mollit proident. Ullamco sunt voluptate sunt quis.',
 };
 
 export default CMCardFoldout;

--- a/src/components/CMCardOverlay.tsx
+++ b/src/components/CMCardOverlay.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Dialog,
   Box,
+  Slide,
 } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton';
 // import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
@@ -49,6 +50,7 @@ const useStyles = makeStyles(() =>
     paper: {
       maxWidth: 'calc(100% - 24px) !important',
       marginTop: '24px',
+      marginBottom: '18px',
     },
     media: {
       margin: 0,
@@ -100,27 +102,28 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
           paperWidthSm: classes.paper,
         }}
       >
-        <Card className={classes.card}>
-          <CardContent>
-            <Box
-              display="flex"
-              flexDirection="column"
-              alignItems="center"
-              justifyContent="center"
-              className={classes.topActions}
-            >
-              <Typography variant="body1" component="p">
-                Close
-              </Typography>
-              <IconButton
-                aria-label="show more"
-                onClick={handleShowMoreClick}
-                className={classes.arrow}
+        <Slide direction="down" in={showMore} mountOnEnter unmountOnExit>
+          <Card className={classes.card}>
+            <CardContent>
+              <Box
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                justifyContent="center"
+                className={classes.topActions}
               >
-                <ArrowDown />
-              </IconButton>
-            </Box>
-            {/* <Typography
+                <Typography variant="body1" component="p">
+                  Close
+                </Typography>
+                <IconButton
+                  aria-label="show more"
+                  onClick={handleShowMoreClick}
+                  className={classes.arrow}
+                >
+                  <ArrowDown />
+                </IconButton>
+              </Box>
+              {/* <Typography
               className={classes.pretitle}
               gutterBottom
               variant="overline"
@@ -128,51 +131,52 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
             >
               Achievement
             </Typography> */}
-            <Grid
-              container
-              direction="row"
-              alignItems="center"
-              justify="space-between"
-            >
-              <Grid item xs={9}>
-                <Typography
-                  className={classes.title}
-                  gutterBottom
-                  variant="h6"
-                  component="h2"
-                >
-                  {title}
-                </Typography>
-              </Grid>
-              {/* <Grid item xs={1}>
+              <Grid
+                container
+                direction="row"
+                alignItems="center"
+                justify="space-between"
+              >
+                <Grid item xs={9}>
+                  <Typography
+                    className={classes.title}
+                    gutterBottom
+                    variant="h6"
+                    component="h2"
+                  >
+                    {title}
+                  </Typography>
+                </Grid>
+                {/* <Grid item xs={1}>
                 <IconButton aria-label="bookmark" className={classes.bookmark}>
                   <BookmarkBorderIcon />
                 </IconButton>
               </Grid> */}
-            </Grid>
-          </CardContent>
+              </Grid>
+            </CardContent>
 
-          {imageUrl && (
-            <CardMedia
-              className={classes.media}
-              image={imageUrl}
-              title={`${title} icon`}
-              data-testid="CMCard-Image"
-            />
-          )}
-
-          <CardContent>
-            <Typography variant="body1" component="p">
-              {shortDescription}
-            </Typography>
-
-            {description && (
-              <Typography variant="body1" component="p">
-                {description}
-              </Typography>
+            {imageUrl && (
+              <CardMedia
+                className={classes.media}
+                image={imageUrl}
+                title={`${title} icon`}
+                data-testid="CMCard-Image"
+              />
             )}
-          </CardContent>
-        </Card>
+
+            <CardContent>
+              <Typography variant="body1" component="p">
+                {shortDescription}
+              </Typography>
+
+              {description && (
+                <Typography variant="body1" component="p">
+                  {description}
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+        </Slide>
       </Dialog>
       <CardContent>
         <Button

--- a/src/components/CMCardOverlay.tsx
+++ b/src/components/CMCardOverlay.tsx
@@ -51,6 +51,7 @@ const useStyles = makeStyles(() =>
       maxWidth: 'calc(100% - 24px) !important',
       marginTop: '24px',
       marginBottom: '18px',
+      height: '100%',
     },
     media: {
       margin: 0,
@@ -96,7 +97,7 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
         aria-labelledby="simple-dialog-title"
         open={showMore}
         fullWidth={true}
-        scroll="body"
+        scroll="paper"
         maxWidth="sm"
         classes={{
           paperWidthSm: classes.paper,

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -43,14 +43,15 @@ const ClimateFeed: React.FC = () => {
               key={`value-${i}`}
               index={i}
               title={effect.effectTitle}
-              shortDescription={effect.effectDescription}
+              shortDescription={effect.effectShortDescription}
               numberedCards={false}
               imageUrl={effect.imageUrl}
               footer={
                 <CMCardOverlay
                   title={effect.effectTitle}
                   imageUrl={effect.imageUrl}
-                  shortDescription={effect.effectDescription}
+                  shortDescription={effect.effectShortDescription}
+                  description={effect.effectDescription}
                 />
               }
             />

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -47,6 +47,7 @@ export type TClimateEffect = {
   effectId: string;
   effectTitle: string;
   effectDescription: string;
+  effectShortDescription: string;
   effectScore: number;
   imageUrl: string;
 };


### PR DESCRIPTION
# ✨ Feature - [Climate effect cards show correct short and long descriptions](https://climatemind.atlassian.net/browse/CM-220l)

## Details
- Update the climate feed card to show the short desc
- Update the foldout to show short + long desc 



<img width="427" alt="Screenshot 2020-11-28 at 11 54 15" src="https://user-images.githubusercontent.com/44759513/100515032-311d4780-3171-11eb-84a7-9a3c82bef339.png">
<img width="425" alt="Screenshot 2020-11-28 at 11 54 21" src="https://user-images.githubusercontent.com/44759513/100515035-32e70b00-3171-11eb-8605-5335b8a34559.png">
