### PR TITLE
added ActionHeadline w corresponding stories and tests

### DIFF
--- a/src/__tests__/src/__components__/CMCard.test.tsx
+++ b/src/__tests__/src/__components__/CMCard.test.tsx
@@ -76,7 +76,22 @@ describe('CMCard', () => {
     const expandFooter = getByText(/MORE/i);
     fireEvent.click(expandFooter);
     expect(getByText(/footer title overlay/i)).toBeInTheDocument();
+  }); 
+  
+  it('It shows an Action Headline', () => {
+    const { getByTestId, getByText } = render(
+      <CMCard
+        title={title}
+        shortDescription={shortDescription}
+        index={1}
+        footer={<CMCardOverlay title='footer title overlay' shortDescription='footer description overlay'/>} 
+        actionHeadline='Reducing Food Waste'
+      />
+    );
+    expect(getByTestId('ActionHeadline')).toBeInTheDocument();
+    expect(getByText(/reducing food waste/i)).toBeInTheDocument();
   });
+
   
   it('It shows the image', () => {
     const { getByTestId } = render(

--- a/src/common/styles/CMTheme.ts
+++ b/src/common/styles/CMTheme.ts
@@ -6,6 +6,7 @@ export const COLORS = {
   PRIMARY: '#FFFFFF',
   SECONDARY: '#39F5AD',
   DK_GREEN: '#07373B',
+  YELLOW: '#FDED6D',
 };
 
 // TODO - move values to constants

--- a/src/components/ActionHeadline.tsx
+++ b/src/components/ActionHeadline.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  CardContent,
+  Typography,
+  Grid,
+} from '@material-ui/core';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { COLORS } from '../common/styles/CMTheme';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+    },
+    content: {
+      maxHeight: '50px',
+      backgroundColor:  COLORS.YELLOW,
+      width: '100%',
+      paddingTop: '0.4em',
+      marginBottom: '-5px'
+    },
+    smallTitle: {
+      textTransform: 'uppercase',
+      letterSpacing: '1pt',
+      marginBottom: '-0.6em',
+    },
+    headline: {},
+    iconContainer: {
+      marginLeft: '-10px'
+    }
+  })
+);
+
+export interface ActionHeadlineProps {
+  actionHeadline: string;
+  smallTitle?: string;
+  icon?: React.ReactNode;
+};
+
+const ActionHeadline: React.FC<ActionHeadlineProps> = ({
+  actionHeadline, icon, smallTitle
+}: ActionHeadlineProps) => {
+  const classes = useStyles();
+
+  return (
+    <CardContent className={classes.content} data-testid="ActionHeadline">
+      <Grid
+        container
+        direction="row"
+        alignItems="center"
+        justify="space-between"
+      >
+        <Grid container item xs={2} justify="center" className={classes.iconContainer}>
+          {icon}
+        </Grid>
+        <Grid item xs={10}>
+          <Grid container direction="column">
+            <Typography
+              className={classes.smallTitle}
+              gutterBottom
+              variant="overline"
+              component="p"
+            >
+              {smallTitle}
+            </Typography>
+            <Typography
+              className={classes.headline}
+              gutterBottom
+              variant="h6"
+              component="h2"
+            >
+              {actionHeadline}
+            </Typography>
+          </Grid>
+        </Grid>
+      </Grid>
+    </CardContent>
+  );
+};
+
+ActionHeadline.defaultProps = {
+  smallTitle: 'Action',
+};
+
+export default ActionHeadline;

--- a/src/components/CMCard.tsx
+++ b/src/components/CMCard.tsx
@@ -9,6 +9,8 @@ import {
 } from '@material-ui/core';
 
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import ActionHeadline from './ActionHeadline';
+import EmojiObjectsIcon from '@material-ui/icons/EmojiObjects';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -50,6 +52,7 @@ export interface CMCardProps {
   numberedCards?: boolean;
   imageUrl?: string;
   footer?: React.ReactNode;
+  actionHeadline?: string;
 }
 
 const CMCard: React.FC<CMCardProps> = ({
@@ -59,6 +62,7 @@ const CMCard: React.FC<CMCardProps> = ({
   numberedCards,
   imageUrl,
   footer,
+  actionHeadline,
 }: CMCardProps) => {
   const classes = useStyles();
 
@@ -108,7 +112,10 @@ const CMCard: React.FC<CMCardProps> = ({
           </Typography>
         </CardContent>
         {footer} 
-      </Card>
+        {actionHeadline && (
+          <ActionHeadline actionHeadline={actionHeadline} icon={<EmojiObjectsIcon fontSize="default"/>} />
+        )}
+        </Card>
     </Grid>
   );
 };

--- a/src/components/CMCardOverlay.tsx
+++ b/src/components/CMCardOverlay.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles(() =>
       marginBottom: '-0.5em',
       fontSize: '11pt',
       letterSpacing: '1pt',
+      paddingLeft: 0,
     },
     topActions: {
       marginTop: '-15px',
@@ -173,14 +174,16 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
           </CardContent>
         </Card>
       </Dialog>
-      <Button
-        className={classes.more}
-        variant="text"
-        onClick={handleShowMoreClick}
-        data-testid="CMCardMore"
-      >
-        MORE
-      </Button>
+      <CardContent>
+        <Button
+          className={classes.more}
+          variant="text"
+          onClick={handleShowMoreClick}
+          data-testid="CMCardMore"
+        >
+          LEARN MORE
+        </Button>
+      </CardContent>
     </>
   );
 };

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -43,6 +43,7 @@ const ClimateFeed: React.FC = () => {
               shortDescription={effect.effectDescription}
               numberedCards={false}
               imageUrl={effect.imageUrl}
+              actionHeadline={effect.actionHeadline}
               footer={
                 <CMCardOverlay
                   title={effect.effectTitle}

--- a/src/stories/components/ActionHeadline.stories.tsx
+++ b/src/stories/components/ActionHeadline.stories.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { Done } from "@material-ui/icons";
+
+import ActionHeadline, { ActionHeadlineProps } from '../../components/ActionHeadline';
+
+export default {
+  title: 'ClimateMind/components/ActionHeadline',
+  component: ActionHeadline,
+} as Meta;
+
+const Template: Story<ActionHeadlineProps> = (args) => <ActionHeadline {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  // headline: 'Default',
+};
+export const Headline = Template.bind({});
+Headline.args = {
+  actionHeadline: 'Reducing Food Waste',
+};
+
+export const Icon = Template.bind({});
+Icon.args = {
+  actionHeadline: 'Reducing Food Waste!',
+  icon:  <Done/>,
+};

--- a/src/stories/components/CMCard.stories.tsx
+++ b/src/stories/components/CMCard.stories.tsx
@@ -80,3 +80,21 @@ WithOverlay.args = {
     </>
   ),
 };
+
+export const WithActionHeadline = Template.bind({});
+WithActionHeadline.args = {
+  title: 'CMCard Overlay!',
+  numberedCards: false,
+  index: 1,
+  shortDescription: `${shortDesc}`,
+  footer: (
+    <>
+      <CMCardOverlay
+        title="Overlay Title"
+        imageUrl={image}
+        shortDescription={detailsDesc}
+      />
+    </>
+  ),
+  actionHeadline: 'Reducing Food Waste'
+};

--- a/src/stories/pages/ClimateFeed.stories.tsx
+++ b/src/stories/pages/ClimateFeed.stories.tsx
@@ -26,6 +26,7 @@ const ClimateFeed: React.FC = () => {
 
   const climateFeed = [
     {
+      actionHeadline: "Reducing Food Waste",
       effectDescription: 'No short desc available at present',
       effectId: 'R8t0oNsG3WgnupXsBVSjMHZ',
       effectScore: 14,
@@ -34,6 +35,7 @@ const ClimateFeed: React.FC = () => {
         'https://yaleclimateconnections.org/wp-content/uploads/2018/04/041718_child_factories.jpg',
     },
     {
+      actionHeadline: "Reducing Food Waste",
       effectDescription: 'No short desc available at present',
       effectId: 'R8epBa4UvcieLTynfK3E84u',
       effectScore: 14,
@@ -73,6 +75,7 @@ const ClimateFeed: React.FC = () => {
                   shortDescription={effect.effectDescription}
                 />
               }
+              actionHeadline={effect.actionHeadline}
             />
           ))}
         </Grid>

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -49,13 +49,10 @@ export type TClimateEffect = {
   effectDescription: string;
   effectScore: number;
   imageUrl: string;
+  actionHeadline: string;
 };
 
 // export type TPersonalValues = [TPersonalValue];
 export type TPersonalValues = {
   personalValues: [TPersonalValue];
 };
-
-// export type TPersonalValuesObj = {
-//   personalValues: TPersonalValues
-// };


### PR DESCRIPTION
Added component ActionHeadline with corresponding stories and tests. The yellow element doesn't show up 
yet since there is no data to show from backend. With mocked data in Storybook we have this look:

![action_headline](https://user-images.githubusercontent.com/10048951/100549913-652e6080-3276-11eb-89f9-e526f28cb9ac.png)
