### PR TITLE
CM-226 Overlay card can scroll with long content

### DIFF
--- a/src/components/CMCard.tsx
+++ b/src/components/CMCard.tsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles((theme: Theme) =>
       backgroundColor: '#fff',
       height: '100%',
       width: '100%',
-      // minWidth: '343px',
     },
     cardHeader: {
       paddingTop: '8px',
@@ -33,7 +32,6 @@ const useStyles = makeStyles((theme: Theme) =>
       marginBottom: '-0.3em',
     },
     media: {
-      // height: '100px',
       margin: 0,
       paddingTop: '56.25%',
     },

--- a/src/components/CMCardOverlay.tsx
+++ b/src/components/CMCardOverlay.tsx
@@ -104,6 +104,7 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
           <div className={classes.card}>
             <DialogTitle className={classes.dialogHeader}>
               <Grid
+                container
                 item
                 direction="column"
                 alignItems="center"

--- a/src/components/CMCardOverlay.tsx
+++ b/src/components/CMCardOverlay.tsx
@@ -11,48 +11,48 @@ import {
   DialogContent,
   Box,
   Slide,
+  Theme,
 } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton';
 // import BookmarkBorderIcon from '@material-ui/icons/BookmarkBorder';
 
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       width: '100%',
     },
-    more: {
+    paper: {
+      maxWidth: 'calc(100% - 24px) !important',
+      height: '100%',
+    },
+    dialogHeader: {
+      textAlign: 'center',
+      position: 'sticky',
+      top: 0,
+      left: 0,
+      backgroundColor: '#FFF',
+      paddingTop: theme.spacing(1),
+      paddingBottom: theme.spacing(1),
+    },
+    dialogContent: {
+      padding: 0,
+    },
+    moreText: {
       textTransform: 'capitalize',
       marginBottom: '-0.5em',
       fontSize: '11pt',
       letterSpacing: '1pt',
       paddingLeft: 0,
     },
-    topActions: {
-      marginTop: '-15px',
-    },
-    pretitle: {
-      textTransform: 'uppercase',
-      letterSpacing: '1pt',
-      fontSize: '10px',
-      marginBottom: '0.3em',
-      marginTop: '1em',
-    },
-    title: {
+    titleText: {
       textTransform: 'capitalize',
       margin: '0.3em 0 0',
+      padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
     },
     card: {
-      backgroundColor: '#fff',
-      height: '100%',
       minWidth: '343px',
-    },
-    paper: {
-      maxWidth: 'calc(100% - 24px) !important',
-      marginTop: '24px',
-      marginBottom: '18px',
-      height: '100%',
     },
     media: {
       margin: 0,
@@ -61,11 +61,6 @@ const useStyles = makeStyles(() =>
     arrow: {
       padding: 0,
       marginTop: '-7px',
-    },
-    bookmark: {
-      color: '#07373B',
-      height: '24px',
-      marginTop: '-0.3em',
     },
   })
 );
@@ -95,7 +90,8 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
     <>
       <Dialog
         onClose={handleShowMoreClick}
-        aria-labelledby="simple-dialog-title"
+        aria-labelledby="scroll-dialog-title"
+        aria-describedby="climate-effect-content"
         open={showMore}
         fullWidth={true}
         scroll="paper"
@@ -105,30 +101,37 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
         }}
       >
         <Slide direction="up" in={showMore} mountOnEnter unmountOnExit>
-          <div>
-            <DialogTitle>
+          <div className={classes.card}>
+            <DialogTitle className={classes.dialogHeader}>
               <Grid
-                container
+                item
                 direction="column"
                 alignItems="center"
                 justify="space-between"
               >
-                <Typography variant="body1" component="p">
-                  Close
-                </Typography>
-                <IconButton
-                  aria-label="show more"
-                  onClick={handleShowMoreClick}
-                  className={classes.arrow}
-                >
-                  <ArrowDown />
-                </IconButton>
+                <Grid item>
+                  <Typography variant="body1" component="p">
+                    Close
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  <IconButton
+                    aria-label="close"
+                    onClick={handleShowMoreClick}
+                    className={classes.arrow}
+                  >
+                    <ArrowDown />
+                  </IconButton>
+                </Grid>
               </Grid>
             </DialogTitle>
-
-            <DialogContent>
+            <DialogContent
+              classes={{ root: classes.dialogContent }}
+              dividers={false}
+              id="climate-effect-content"
+            >
               <Typography
-                className={classes.title}
+                className={classes.titleText}
                 gutterBottom
                 variant="h6"
                 component="h2"
@@ -144,16 +147,17 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
                   data-testid="CMCard-Image"
                 />
               )}
-
-              <Typography variant="body1" component="p">
-                {shortDescription}
-              </Typography>
-
-              {description && (
+              <Box p={2}>
                 <Typography variant="body1" component="p">
-                  {description}
+                  {shortDescription}
                 </Typography>
-              )}
+
+                {description && (
+                  <Typography variant="body1" component="p">
+                    {description}
+                  </Typography>
+                )}
+              </Box>
             </DialogContent>
           </div>
         </Slide>
@@ -161,7 +165,7 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
 
       <CardContent>
         <Button
-          className={classes.more}
+          className={classes.moreText}
           variant="text"
           onClick={handleShowMoreClick}
           data-testid="CMCardMore"

--- a/src/components/CMCardOverlay.tsx
+++ b/src/components/CMCardOverlay.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { ReactComponent as ArrowDown } from '../assets/icon-arrow-down.svg';
 import {
-  Card,
   CardMedia,
   CardContent,
   Typography,
   Grid,
   Button,
   Dialog,
+  DialogTitle,
+  DialogContent,
   Box,
   Slide,
 } from '@material-ui/core';
@@ -103,15 +104,14 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
           paperWidthSm: classes.paper,
         }}
       >
-        <Slide direction="down" in={showMore} mountOnEnter unmountOnExit>
-          <Card className={classes.card}>
-            <CardContent>
-              <Box
-                display="flex"
-                flexDirection="column"
+        <Slide direction="up" in={showMore} mountOnEnter unmountOnExit>
+          <div>
+            <DialogTitle>
+              <Grid
+                container
+                direction="column"
                 alignItems="center"
-                justifyContent="center"
-                className={classes.topActions}
+                justify="space-between"
               >
                 <Typography variant="body1" component="p">
                   Close
@@ -123,49 +123,28 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
                 >
                   <ArrowDown />
                 </IconButton>
-              </Box>
-              {/* <Typography
-              className={classes.pretitle}
-              gutterBottom
-              variant="overline"
-              component="p"
-            >
-              Achievement
-            </Typography> */}
-              <Grid
-                container
-                direction="row"
-                alignItems="center"
-                justify="space-between"
-              >
-                <Grid item xs={9}>
-                  <Typography
-                    className={classes.title}
-                    gutterBottom
-                    variant="h6"
-                    component="h2"
-                  >
-                    {title}
-                  </Typography>
-                </Grid>
-                {/* <Grid item xs={1}>
-                <IconButton aria-label="bookmark" className={classes.bookmark}>
-                  <BookmarkBorderIcon />
-                </IconButton>
-              </Grid> */}
               </Grid>
-            </CardContent>
+            </DialogTitle>
 
-            {imageUrl && (
-              <CardMedia
-                className={classes.media}
-                image={imageUrl}
-                title={`${title} icon`}
-                data-testid="CMCard-Image"
-              />
-            )}
+            <DialogContent>
+              <Typography
+                className={classes.title}
+                gutterBottom
+                variant="h6"
+                component="h2"
+              >
+                {title}
+              </Typography>
 
-            <CardContent>
+              {imageUrl && (
+                <CardMedia
+                  className={classes.media}
+                  image={imageUrl}
+                  title={`${title} icon`}
+                  data-testid="CMCard-Image"
+                />
+              )}
+
               <Typography variant="body1" component="p">
                 {shortDescription}
               </Typography>
@@ -175,10 +154,11 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
                   {description}
                 </Typography>
               )}
-            </CardContent>
-          </Card>
+            </DialogContent>
+          </div>
         </Slide>
       </Dialog>
+
       <CardContent>
         <Button
           className={classes.more}

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -37,7 +37,7 @@ const ClimateFeed: React.FC = () => {
         data-testid="ClimateFeed"
         justify="space-around"
       >
-        <Grid item sm={12} lg={12} container className={classes.feedContainer}>
+        <Grid item sm={12} lg={12} className={classes.feedContainer}>
           {climateFeed.map((effect, i) => (
             <CMCard
               key={`value-${i}`}

--- a/src/stories/components/CMCard.stories.tsx
+++ b/src/stories/components/CMCard.stories.tsx
@@ -2,19 +2,26 @@ import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Story, Meta } from '@storybook/react/types-6-0';
 
-// import { Button, ButtonProps } from './Button';
-
 import CMCard, { CMCardProps } from '../../components/CMCard';
 import CMCardFoldout from '../../components/CMCardFoldout';
 import CMCardOverlay from '../../components/CMCardOverlay';
+
+// Dummy Data
+const effect = {
+  title: 'Climate Effect Title',
+  description:
+    'Excepteur labore deserunt aliquip consectetur cupidatat aliqua. Laborum laboris duis veniam ad cupidatat dolor velit. Cillum amet ea do elit adipisicing elit Lorem. Voluptate dolor deserunt laboris nulla excepteur aute occaecat aliqua occaecat. Non ea sunt cupidatat cupidatat nostrud consequat in. Excepteur labore deserunt aliquip consectetur cupidatat aliqua. Laborum laboris duis veniam ad cupidatat dolor velit. Cillum amet ea do elit adipisicing elit Lorem. Voluptate dolor deserunt laboris nulla excepteur aute occaecat aliqua occaecat. Non ea sunt cupidatat cupidatat nostrud consequat in. Excepteur labore deserunt aliquip consectetur cupidatat aliqua. Laborum laboris duis veniam ad cupidatat dolor velit. Cillum amet ea do elit adipisicing elit Lorem. Voluptate dolor deserunt laboris nulla excepteur aute occaecat aliqua occaecat. Non ea sunt cupidatat cupidatat nostrud consequat in. Excepteur labore deserunt aliquip consectetur cupidatat aliqua. Laborum laboris duis veniam ad cupidatat dolor velit. Cillum amet ea do elit adipisicing elit Lorem. Voluptate dolor deserunt laboris nulla excepteur aute occaecat aliqua occaecat. Non ea sunt cupidatat cupidatat nostrud consequat in. Excepteur labore deserunt aliquip consectetur cupidatat aliqua. Laborum laboris duis veniam ad cupidatat dolor velit. Cillum amet ea do elit adipisicing elit Lorem. Voluptate dolor deserunt laboris nulla excepteur aute occaecat aliqua occaecat. Non ea sunt cupidatat cupidatat nostrud consequat in. Excepteur labore deserunt aliquip consectetur cupidatat aliqua. Laborum laboris duis veniam ad cupidatat dolor velit. Cillum amet ea do elit adipisicing elit Lorem. Voluptate dolor deserunt laboris nulla excepteur aute occaecat aliqua occaecat. Non ea sunt cupidatat cupidatat nostrud consequat in.',
+  shortDescription:
+    'Veniam qui in nisi irure anim qui aute id. Amet do adipisicing excepteur fugiat duis eu pariatur sint adipisicing dolore dolore duis. Esse irure eu nulla nostrud veniam labore fugiat laborum ex sit amet.',
+  imageUrl:
+    'https://yaleclimateconnections.org/wp-content/uploads/2018/04/041718_child_factories.jpg',
+  actionHeadline: 'Reducing Food Waste',
+};
 
 export default {
   title: 'ClimateMind/components/CMCard',
   component: CMCard,
 } as Meta;
-
-const image =
-  'https://yaleclimateconnections.org/wp-content/uploads/2018/04/041718_child_factories.jpg';
 
 const Template: Story<CMCardProps> = (args) => <CMCard {...args} />;
 
@@ -23,43 +30,38 @@ DefaultCard.args = {};
 
 export const WithTitle = Template.bind({});
 WithTitle.args = {
-  title: 'This is a Title',
+  title: effect.title,
   numberedCards: false,
-  index: 1,
+  index: 2,
 };
-
-const shortDesc =
-  'Personal success through demonstrating competence according to social standards is your jam. You strive to be the best and in turn can obtain social approval. You are ambitious, successful, capable and influential.';
 
 export const WithDescription = Template.bind({});
 WithDescription.args = {
-  title: 'Long title here',
+  title: effect.title,
   numberedCards: false,
-  index: 1,
-  shortDescription: `${shortDesc}`,
+  index: 2,
+  shortDescription: `${effect.shortDescription}`,
 };
 
 export const WithImage = Template.bind({});
 WithImage.args = {
-  title: 'Long title here',
+  title: effect.title,
   numberedCards: false,
   index: 1,
-  shortDescription: `${shortDesc}`,
+  shortDescription: `${effect.shortDescription}`,
   imageUrl:
     'https://yaleclimateconnections.org/wp-content/uploads/2018/04/041718_child_factories.jpg',
 };
-
-const detailsDesc = 'Lorem ipsum consit dolor';
 
 export const WithFoldout = Template.bind({});
 WithFoldout.args = {
   title: 'Long title here',
   numberedCards: false,
   index: 1,
-  shortDescription: `${shortDesc}`,
+  shortDescription: `${effect.shortDescription}`,
   footer: (
     <>
-      <CMCardFoldout description={detailsDesc}></CMCardFoldout>
+      <CMCardFoldout description={effect.description}></CMCardFoldout>
     </>
   ),
 };
@@ -69,13 +71,14 @@ WithOverlay.args = {
   title: 'CMCard Overlay!',
   numberedCards: false,
   index: 1,
-  shortDescription: `${shortDesc}`,
+  shortDescription: effect.shortDescription,
   footer: (
     <>
       <CMCardOverlay
         title="Overlay Title"
-        imageUrl={image}
-        shortDescription={detailsDesc}
+        imageUrl={effect.imageUrl}
+        shortDescription={effect.shortDescription}
+        description={effect.description}
       />
     </>
   ),
@@ -86,15 +89,16 @@ WithActionHeadline.args = {
   title: 'CMCard Overlay!',
   numberedCards: false,
   index: 1,
-  shortDescription: `${shortDesc}`,
+  shortDescription: `${effect.shortDescription}`,
   footer: (
     <>
       <CMCardOverlay
         title="Overlay Title"
-        imageUrl={image}
-        shortDescription={detailsDesc}
+        imageUrl={effect.imageUrl}
+        shortDescription={effect.shortDescription}
+        description={effect.description}
       />
     </>
   ),
-  actionHeadline: 'Reducing Food Waste'
+  actionHeadline: 'Reducing Food Waste',
 };


### PR DESCRIPTION
# [Overlay card can scroll with long content](https://climatemind.atlassian.net/browse/CM-226)

## Details
- Overlay component need a bit of re-arranging so as to use <DialogContent> instead of <CMCard>
- Set Dialog scroll prop to "paper" this makes the card scroll rather than the whole screen
- Use position sticky on Close Area so that is fixed on screen (ordinarily this is not needed but was required in this case to make the transition work) 
- made updated the data going into the storybook for the overlay to simulate some long content


## Result
The card can now scroll but the close controls stay on the screen

<img width="438" alt="Screenshot 2020-12-02 at 18 21 14" src="https://user-images.githubusercontent.com/44759513/100915554-69ec5200-34cc-11eb-84f7-33232c5d57af.png">

