### PR TITLE
CM-314 Layout tweaks - Make sure card sizes responsive and consistent

### DIFF
--- a/src/__tests__/src/Home.test.tsx
+++ b/src/__tests__/src/Home.test.tsx
@@ -13,6 +13,6 @@ describe('Home page', () => {
   });
   it('shows Powering climate conversations', () => {
     const { getByText } = render(<Home />);
-    expect(getByText(/Powering climate conversations/i)).toBeInTheDocument();
+    expect(getByText(/Catalyzing Climate Action/i)).toBeInTheDocument();
   });
 });

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
-      zIndex: 99999,
+      zIndex: 888,
       position: 'relative',
     },
     title: {

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -50,7 +50,7 @@ const BottomMenu: React.FC<BottomMenuProps> = ({
         width: '100%',
         position: 'fixed',
         bottom: 0,
-        zIndex: 500,
+        zIndex: 9999,
       },
       actionItem: {
         // These styles are applied to the root element when

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -39,6 +39,7 @@ const PageWrapper: React.FC<WrapperProps> = ({
             {/* left gutter */}
           </Grid>
           <Grid
+            xs={12}
             lg={6}
             item
             container

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -35,7 +35,11 @@ const PageWrapper: React.FC<WrapperProps> = ({
     <>
       <Div100vh className={classes.root}>
         <Grid container direction="row" className={classes.outerGrid}>
+          <Grid item sm={false} lg={3}>
+            {/* left gutter */}
+          </Grid>
           <Grid
+            lg={6}
             item
             container
             direction="column"
@@ -44,6 +48,9 @@ const PageWrapper: React.FC<WrapperProps> = ({
             wrap="nowrap"
           >
             {children}
+          </Grid>
+          <Grid item sm={false} lg={3}>
+            {/* right gutter */}
           </Grid>
         </Grid>
       </Div100vh>

--- a/src/components/PrevButton.tsx
+++ b/src/components/PrevButton.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
       fontFamily: 'Bilo',
       fontSize: '14px',
       cursor: 'pointer',
+      paddingTop: '6px',
     },
     flexChild: {
       '&:first-child': {
@@ -21,34 +22,39 @@ const useStyles = makeStyles((theme: Theme) =>
       },
       '&:last-child': {
         marginTop: '2px',
-      }
+      },
     },
-  }),
+  })
 );
 
 export interface PrevButtonProps {
-    text?: string,
-    clickPrevHandler: () => void,
+  text?: string;
+  clickPrevHandler: () => void;
 }
 
-const PrevButton: React.FC<PrevButtonProps> = ({text, clickPrevHandler}: PrevButtonProps) => {
-
+const PrevButton: React.FC<PrevButtonProps> = ({
+  text,
+  clickPrevHandler,
+}: PrevButtonProps) => {
   const classes = useStyles();
 
-    return (
-      <div className={classes.backButtonContainer} onClick={() => clickPrevHandler()} data-testid="PrevButton">
+  return (
+    <div data-testid="PrevButton">
+      <div
+        className={classes.backButtonContainer}
+        onClick={() => clickPrevHandler()}
+      >
         <div className={classes.flexChild}>
-          <ArrowBack /> 
+          <ArrowBack />
         </div>
-        <div className={classes.flexChild}>
-          {text}
-        </div>
+        <div className={classes.flexChild}>{text}</div>
       </div>
-    );
-}
+    </div>
+  );
+};
 
 PrevButton.defaultProps = {
-    text: 'Back'
-}
+  text: 'Back',
+};
 
 export default PrevButton;

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -4,7 +4,7 @@ import { COLORS } from '../common/styles/CMTheme';
 import Loader from '../components/Loader';
 import Card from '../components/Card';
 import Error500 from '../pages/Error500';
-import PageWrapper from '../components/Wrapper';
+import Wrapper from '../components/Wrapper';
 import CardHeader from '../components/CardHeader';
 import EffectOverlay from '../components/EffectOverlay';
 import { useClimateFeed } from '../hooks/useClimateFeed';
@@ -15,7 +15,6 @@ const useStyles = makeStyles({
     flexGrow: 1,
     minHeight: '100vh',
     padding: 0,
-    maxWidth: 527,
     paddingBottom: 56,
   },
   feedContainer: {
@@ -36,47 +35,76 @@ const ClimateFeed: React.FC = () => {
   }
 
   return (
-    <PageWrapper bgColor={COLORS.ACCENT5} fullHeight>
-      {isLoading && <Loader />}
-
-      {data?.climateEffects && (
-        <Grid
-          container
-          className={classes.root}
-          data-testid="ClimateFeed"
-          justify="space-around"
-        >
-          <Grid item sm={12} lg={12} className={classes.feedContainer}>
-            {data.climateEffects.map((effect, i) => {
-              const preview = effect.effectSolutions[0];
-              return (
-                <Card
-                  header={<CardHeader title={effect.effectTitle} preTitle={'Local impact'} isPossiblyLocal={effect.isPossiblyLocal}/>}
-                  key={`value-${i}`}
-                  index={i}
-                  imageUrl={effect.imageUrl}
-                  footer={<EffectOverlay effect={effect} />}
-                  preview={
-                    <CardHeader
-                      title={preview.solutionTitle}
-                      preTitle={`${preview.solutionType} Action`}
-                      bgColor={COLORS.ACCENT2}
-                      index={i}
-                      cardIcon={preview.solutionType}
-                    />
-                  }
-                >
-                  <Typography variant="body1">
-                    {effect.effectShortDescription}
-                  </Typography>
-                </Card>
-              );
-            })}
+    <>
+      <Grid
+        container
+        className={classes.root}
+        data-testid="Myths Feed"
+        justify="space-around"
+      >
+        <Wrapper bgColor={COLORS.ACCENT5}>
+          <Grid item sm={false} lg={4}>
+            {/* left gutter */}
           </Grid>
-        </Grid>
-      )}
+
+          {isLoading && <Loader />}
+
+          {data?.climateEffects && (
+            <Grid
+              container
+              className={classes.root}
+              data-testid="ClimateFeed"
+              justify="space-around"
+            >
+              <Grid
+                item
+                xs={12}
+                sm={10}
+                md={8}
+                lg={6}
+                className={classes.feedContainer}
+              >
+                {data.climateEffects.map((effect, i) => {
+                  const preview = effect.effectSolutions[0];
+                  return (
+                    <Card
+                      header={
+                        <CardHeader
+                          title={effect.effectTitle}
+                          preTitle={'Local impact'}
+                          isPossiblyLocal={effect.isPossiblyLocal}
+                        />
+                      }
+                      key={`value-${i}`}
+                      index={i}
+                      imageUrl={effect.imageUrl}
+                      footer={<EffectOverlay effect={effect} />}
+                      preview={
+                        <CardHeader
+                          title={preview.solutionTitle}
+                          preTitle={`${preview.solutionType} Action`}
+                          bgColor={COLORS.ACCENT2}
+                          index={i}
+                          cardIcon={preview.solutionType}
+                        />
+                      }
+                    >
+                      <Typography variant="body1">
+                        {effect.effectShortDescription}
+                      </Typography>
+                    </Card>
+                  );
+                })}
+              </Grid>
+            </Grid>
+          )}
+          <Grid item sm={false} lg={4}>
+            {/* right gutter */}
+          </Grid>
+        </Wrapper>
+      </Grid>
       <BottomMenu />
-    </PageWrapper>
+    </>
   );
 };
 

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -15,7 +15,6 @@ const useStyles = makeStyles({
     flexGrow: 1,
     minHeight: '100vh',
     padding: 0,
-    paddingBottom: 56,
   },
   feedContainer: {
     padding: 0,

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -52,18 +52,16 @@ const ClimateFeed: React.FC = () => {
           {data?.climateEffects && (
             <Grid
               container
+              item
+              xs={12}
+              sm={10}
+              md={8}
+              lg={6}
               className={classes.root}
               data-testid="ClimateFeed"
               justify="space-around"
             >
-              <Grid
-                item
-                xs={12}
-                sm={10}
-                md={8}
-                lg={6}
-                className={classes.feedContainer}
-              >
+              <Grid item className={classes.feedContainer}>
                 <Grid item>
                   <Box mt={2} mb={4} mx={2}>
                     <Grid

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography, Box } from '@material-ui/core';
+import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import { COLORS } from '../common/styles/CMTheme';
 import Loader from '../components/Loader';
 import Card from '../components/Card';
@@ -63,6 +64,26 @@ const ClimateFeed: React.FC = () => {
                 lg={6}
                 className={classes.feedContainer}
               >
+                <Grid item>
+                  <Box mt={2} mb={4} mx={2}>
+                    <Grid
+                      container
+                      direction="row"
+                      alignItems="center"
+                      spacing={5}
+                    >
+                      <Grid item xs={3}>
+                        <Logo width="76" data-testid="climate-mind-logo" />
+                      </Grid>
+                      <Grid item xs={9}>
+                        <Typography variant="h4">
+                          Your Personal Climate Feed
+                        </Typography>
+                      </Grid>
+                    </Grid>
+                  </Box>
+                </Grid>
+
                 {data.climateEffects.map((effect, i) => {
                   const preview = effect.effectSolutions[0];
                   return (

--- a/src/pages/ClimatePersonality.tsx
+++ b/src/pages/ClimatePersonality.tsx
@@ -42,8 +42,10 @@ const ClimatePersonality: React.FC<{}> = () => {
     <PageWrapper bgColor="#EFE282">
       <Grid
         item
-        sm={12}
-        lg={4}
+        xs={12}
+        sm={8}
+        md={6}
+        lg={8}
         spacing={5}
         container
         direction="row"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -40,7 +40,7 @@ const Home: React.FC<{}> = () => {
             align="center"
             className={classes.typography}
           >
-            Powering climate conversations
+            Catalyzing Climate Action
           </Typography>
         </Box>
       </Grid>

--- a/src/pages/MeetGuy.tsx
+++ b/src/pages/MeetGuy.tsx
@@ -21,7 +21,7 @@ const MeetGuy: React.FC<{}> = () => {
 
   return (
     <PageWrapper bgColor="#FF9439">
-      <Grid item sm={12} lg={4} className={classes.greeting}>
+      <Grid item className={classes.greeting}>
         <Box>
           <Typography variant="h4">Hello there!</Typography>
         </Box>

--- a/src/pages/MythFeed.tsx
+++ b/src/pages/MythFeed.tsx
@@ -60,10 +60,10 @@ const MythFeed: React.FC = () => {
             lg={6}
             container
             direction="row"
-            justify="center"
+            justify="space-between"
             alignItems="center"
           >
-            <Grid item>
+            <Grid item container direction="row" justify="space-between">
               <Box mt={2} mb={3} mx={2}>
                 <Grid container direction="row" alignItems="center" spacing={5}>
                   <Grid item xs={3}>

--- a/src/pages/MythFeed.tsx
+++ b/src/pages/MythFeed.tsx
@@ -54,8 +54,10 @@ const MythFeed: React.FC = () => {
 
           <Grid
             item
-            sm={12}
-            lg={4}
+            xs={12}
+            sm={10}
+            md={8}
+            lg={6}
             container
             direction="row"
             justify="center"

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -74,8 +74,10 @@ const PersonalValues: React.FC = () => {
 
         <Grid
           item
-          sm={12}
-          lg={4}
+          xs={12}
+          sm={10}
+          md={8}
+          lg={6}
           container
           direction="row"
           justify="center"
@@ -180,8 +182,8 @@ const PersonalValues: React.FC = () => {
           <Grid item sm={12} lg={6}>
             <Box mt={2} mb={3} px={5} textAlign="center">
               <Typography variant="h6">
-              You are about to see the effects of climate change 
-              and how you can take action against it
+                You are about to see the effects of climate change and how you
+                can take action against it
               </Typography>
             </Box>
           </Grid>

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -15,9 +15,11 @@ const styles = makeStyles({
   },
   progressContainer: {
     minHeight: '45px',
+    width: '100%',
   },
   progressBarContainer: {
     height: '12px',
+    width: '100%',
     margin: 0,
     padding: 0,
     '& > *': {
@@ -53,7 +55,7 @@ const Questionaire: React.FC<{}> = () => {
   return (
     <>
       <PageWrapper>
-        <Grid item container justify="center">
+        <Grid item>
           <Box my={2}>
             <Question
               key={currentQuestion.id}
@@ -66,16 +68,20 @@ const Questionaire: React.FC<{}> = () => {
           </Box>
         </Grid>
 
-        <Grid item container className={classes.progressContainer}>
-          <Grid item xs={12} className={classes.progressBarContainer}>
-            <LinearProgress
-              aria-label="Questionnaire Progress"
-              className={classes.progressBar}
-              variant="determinate"
-              color="secondary"
-              value={progress * 10}
-            />
-          </Grid>
+        <Grid
+          item
+          className={classes.progressBarContainer}
+          direction="column"
+          justify="space-between"
+          alignItems="flex-start"
+        >
+          <LinearProgress
+            aria-label="Questionnaire Progress"
+            className={classes.progressBar}
+            variant="determinate"
+            color="secondary"
+            value={progress * 10}
+          />
 
           {progress > 0 && (
             <PrevButton text="Back" clickPrevHandler={changeQuestionBackward} />

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -18,7 +18,6 @@ const styles = makeStyles({
   },
   progressBarContainer: {
     height: '12px',
-
     margin: 0,
     padding: 0,
     '& > *': {
@@ -54,31 +53,21 @@ const Questionaire: React.FC<{}> = () => {
   return (
     <>
       <PageWrapper>
-        <Grid container>
-          <Grid item xs={false} lg={3}>
-            {/* Row 1 - Left Gutter */}
-          </Grid>
-          <Grid item sm={12} lg={6} container justify="center">
-            <Box my={2}>
-              <Question
-                key={currentQuestion.id}
-                questionNumber={progress + 1}
-                questionId={currentQuestion.id}
-                question={currentQuestion.question}
-                answers={answers}
-                setAnswer={setAnswer}
-              />
-            </Box>
-          </Grid>
-          <Grid item xs={false} lg={3}>
-            {/* Right Gutter */}
-          </Grid>
+        <Grid item container justify="center">
+          <Box my={2}>
+            <Question
+              key={currentQuestion.id}
+              questionNumber={progress + 1}
+              questionId={currentQuestion.id}
+              question={currentQuestion.question}
+              answers={answers}
+              setAnswer={setAnswer}
+            />
+          </Box>
         </Grid>
+
         <Grid item container className={classes.progressContainer}>
-          <Grid item xs={false} lg={3}>
-            {/* Row 2 -Left Gutter */}
-          </Grid>
-          <Grid item xs={12} lg={6} className={classes.progressBarContainer}>
+          <Grid item xs={12} className={classes.progressBarContainer}>
             <LinearProgress
               aria-label="Questionnaire Progress"
               className={classes.progressBar}
@@ -87,19 +76,10 @@ const Questionaire: React.FC<{}> = () => {
               value={progress * 10}
             />
           </Grid>
-          <Grid item xs={false} lg={3}>
-            {/* Right Gutter */}
-          </Grid>
 
-          <Grid item xs={false} lg={3}>
-            {/* Row 3 -Left Gutter */}
-          </Grid>
           {progress > 0 && (
             <PrevButton text="Back" clickPrevHandler={changeQuestionBackward} />
           )}
-          <Grid item xs={false} lg={3}>
-            {/* Right Gutter */}
-          </Grid>
         </Grid>
       </PageWrapper>
     </>

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -68,8 +68,10 @@ const SolutionsFeed: React.FC = () => {
 
           <Grid
             item
-            sm={12}
-            lg={4}
+            xs={12}
+            sm={10}
+            md={8}
+            lg={6}
             container
             direction="row"
             justify="center"

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -77,7 +77,7 @@ const SolutionsFeed: React.FC = () => {
             justify="center"
             alignItems="center"
           >
-            <Grid item>
+            <Grid item container direction="row" justify="space-between">
               <Box mt={2} mb={3} mx={2}>
                 <Grid container direction="row" alignItems="center" spacing={5}>
                   <Grid item xs={3}>

--- a/src/pages/SubmitQuestionnaire.tsx
+++ b/src/pages/SubmitQuestionnaire.tsx
@@ -40,7 +40,7 @@ const SubmitQuestionnaire: React.FC<{}> = () => {
           <Logo width="76" data-testid="climate-mind-logo" />
         </Grid>
         <Grid item xs={9}>
-          <Typography variant="h4">Good to meet you!</Typography>
+          <Typography variant="h4">Woohoo! Good Job!</Typography>
         </Grid>
       </Grid>
 

--- a/src/pages/SubmitQuestionnaire.tsx
+++ b/src/pages/SubmitQuestionnaire.tsx
@@ -35,26 +35,16 @@ const SubmitQuestionnaire: React.FC<{}> = () => {
 
   return (
     <PageWrapper bgColor="#FF9439">
-      <Grid
-        item
-        sm={12}
-        lg={4}
-        container
-        direction="column"
-        justify="space-between"
-        alignItems="center"
-      >
-        <Grid container direction="row" alignItems="center" spacing={5}>
-          <Grid item xs={3}>
-            <Logo width="76" data-testid="climate-mind-logo" />
-          </Grid>
-          <Grid item xs={9}>
-            <Typography variant="h4">Woohoo! Good Job!</Typography>
-          </Grid>
+      <Grid item spacing={5} container direction="row" alignItems="center">
+        <Grid item xs={3}>
+          <Logo width="76" data-testid="climate-mind-logo" />
+        </Grid>
+        <Grid item xs={9}>
+          <Typography variant="h4">Good to meet you!</Typography>
         </Grid>
       </Grid>
 
-      <Grid item sm={12} lg={4}>
+      <Grid item>
         <Box textAlign="center">
           <Typography variant="h6">
             With the questions you just answered I can predict your Climate
@@ -69,7 +59,7 @@ const SubmitQuestionnaire: React.FC<{}> = () => {
         </Box>
       </Grid>
 
-      <Grid item sm={12} lg={4}>
+      <Grid item>
         <Box textAlign="center">
           <Typography variant="body1">
             This is a ranking of the top three personal values that you deploy


### PR DESCRIPTION
- Adjusted the meetguy page so that top element didn't take up 3/4 of the screen on larger devies.
- Tweaked all the feed pages to make sure the card sizes are responsive and consistent accross, Personal Values, Climate feed, Myth Feed, Solutions Feed.

<img width="543" alt="Screenshot 2021-01-09 at 19 21 49" src="https://user-images.githubusercontent.com/44759513/104106851-59d84700-52b0-11eb-98ad-3898d71c62cc.png">
<img width="1225" alt="Screenshot 2021-01-09 at 19 21 56" src="https://user-images.githubusercontent.com/44759513/104106854-5c3aa100-52b0-11eb-8d23-a2807160ee30.png">
<img width="1793" alt="Screenshot 2021-01-09 at 19 22 07" src="https://user-images.githubusercontent.com/44759513/104106855-5e9cfb00-52b0-11eb-8fd7-cd929169f86c.png">

