### PR TITLE
CM-343 scroll to top on mount

### DIFF
--- a/src/components/ScrollToTopOnMount.tsx
+++ b/src/components/ScrollToTopOnMount.tsx
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+export default function ScrollToTopOnMount() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  return null;
+}

--- a/src/components/ScrollToTopOnMount.tsx
+++ b/src/components/ScrollToTopOnMount.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+// https://reactrouter.com/web/guides/scroll-restoration
 
 export default function ScrollToTopOnMount() {
   useEffect(() => {

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -9,6 +9,7 @@ import CardHeader from '../components/CardHeader';
 import EffectOverlay from '../components/EffectOverlay';
 import { useClimateFeed } from '../hooks/useClimateFeed';
 import BottomMenu from '../components/BottomMenu';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const useStyles = makeStyles({
   root: {
@@ -39,6 +40,8 @@ const ClimateFeed: React.FC = () => {
     <PageWrapper bgColor={COLORS.ACCENT5} fullHeight>
       {isLoading && <Loader />}
 
+      <ScrollToTopOnMount />
+
       {data?.climateEffects && (
         <Grid
           container
@@ -51,7 +54,13 @@ const ClimateFeed: React.FC = () => {
               const preview = effect.effectSolutions[0];
               return (
                 <Card
-                  header={<CardHeader title={effect.effectTitle} preTitle={'Local impact'} isPossiblyLocal={effect.isPossiblyLocal}/>}
+                  header={
+                    <CardHeader
+                      title={effect.effectTitle}
+                      preTitle={'Local impact'}
+                      isPossiblyLocal={effect.isPossiblyLocal}
+                    />
+                  }
                   key={`value-${i}`}
                   index={i}
                   imageUrl={effect.imageUrl}

--- a/src/pages/GetZipCode.tsx
+++ b/src/pages/GetZipCode.tsx
@@ -10,6 +10,7 @@ import { containsInvalidZipChars, isValidZipCode } from '../helpers/zipCodes';
 import TextField from '../components/TextInput';
 import { useSession } from '../hooks/useSession';
 import Button from '../components/Button';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -71,6 +72,8 @@ const GetZipCode: React.FC<{}> = () => {
   return (
     <PageWrapper bgColor={COLORS.ACCENT1}>
       {/* Page header */}
+
+      <ScrollToTopOnMount />
 
       <Grid
         item

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { ReactComponent as Logo } from '../assets/cm-logo-home.svg';
 import ROUTES from '../components/Router/RouteConfig';
 import PageWrapper from '../components/PageWrapper';
 import Button from '../components/Button';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const styles = makeStyles((theme) => {
   return {
@@ -29,6 +30,8 @@ const Home: React.FC<{}> = () => {
           <Logo data-testid="climate-mind-logo" />
         </Box>
       </Grid>
+
+      <ScrollToTopOnMount />
 
       <Grid item>
         <Box>

--- a/src/pages/MythFeed.tsx
+++ b/src/pages/MythFeed.tsx
@@ -9,6 +9,7 @@ import Error500 from './Error500';
 import MythCard from '../components/MythCard';
 import Wrapper from '../components/Wrapper';
 import BottomMenu from '../components/BottomMenu';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const styles = makeStyles({
   root: {
@@ -51,6 +52,8 @@ const MythFeed: React.FC = () => {
           <Grid item sm={false} lg={4}>
             {/* left gutter */}
           </Grid>
+
+          <ScrollToTopOnMount />
 
           <Grid
             item

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -6,6 +6,7 @@ import { Typography, Grid, makeStyles, Box } from '@material-ui/core';
 import Wrapper from '../components/Wrapper';
 import { useHistory } from 'react-router';
 import PrivacyPolicyText from '../components/PrivacyPolicyText';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const styles = makeStyles({
   root: {
@@ -35,6 +36,8 @@ const PrivacyPolicy: React.FC = () => {
         <Grid item sm={false} lg={4}>
           {/* left gutter */}
         </Grid>
+
+        <ScrollToTopOnMount />
 
         <Grid
           item

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -11,6 +11,7 @@ import Error500 from './Error500';
 import Wrapper from '../components/Wrapper';
 import BottomMenu from '../components/BottomMenu';
 import SolutionOverlay from '../components/SolutionOverlay';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const styles = makeStyles({
   root: {
@@ -65,6 +66,8 @@ const SolutionsFeed: React.FC = () => {
           <Grid item sm={false} lg={4}>
             {/* left gutter */}
           </Grid>
+
+          <ScrollToTopOnMount />
 
           <Grid
             item

--- a/src/pages/SubmitQuestionnaire.tsx
+++ b/src/pages/SubmitQuestionnaire.tsx
@@ -10,6 +10,7 @@ import { useResponsesData } from '../hooks/useResponses';
 import { useSession } from '../hooks/useSession';
 import PageWrapper from '../components/PageWrapper';
 import { useClimatePersonality } from '../hooks/useClimatePersonality';
+import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 
 const SubmitQuestionnaire: React.FC<{}> = () => {
   const history = useHistory();
@@ -53,6 +54,8 @@ const SubmitQuestionnaire: React.FC<{}> = () => {
           </Grid>
         </Grid>
       </Grid>
+
+      <ScrollToTopOnMount />
 
       <Grid item sm={12} lg={4}>
         <Box textAlign="center">


### PR DESCRIPTION
This feature creates the `ScrollToTopOnMount.tsx` component and imports it into several page components.

There is a more elegant way to do this:
In Router/BrowserRouter: you can do this:

```
<Router onUpdate={() => window.scrollTo(0, 0)}}>
```

But due to me being new to typescript, I'm not sure how to solve TS yelling at me for this more elegant approach: 

<img width="500" alt="Screen Shot 2021-01-09 at 6 58 50 PM" src="https://user-images.githubusercontent.com/59632599/104111136-ca7d6480-52ac-11eb-8dbb-cbdac6a599aa.png">

however the pushed approach has its pros, what if you don't want to scroll to top on mount for every component? that way you can just import  `ScrollToTopOnMount.tsx` to any page that needs it, additionally, I'm not sure how the sticky navbar would react to the other approach that I tried.