### PR TITLE
 CM-158 down icon incorrectly positioned

### DIFF
--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -26,6 +26,10 @@ const styles = makeStyles({
   typography: {
     textAlign: 'center',
   },
+  grid: {
+    flexDirection: 'column',
+    alignItems: 'center',
+  }
 });
 
 const PersonalValues: React.FC = () => {
@@ -125,7 +129,7 @@ const PersonalValues: React.FC = () => {
               ))}
           </Grid>
 
-          <Grid item sm={12} lg={6} container justify="center">
+          <Grid className={classes.grid} item sm={12} lg={6} container justify="center">
             <Box mt={6} mb={4} px={2} textAlign="center">
               <Typography variant="h6">
                 Climate Personality not quite right?
@@ -180,8 +184,8 @@ const PersonalValues: React.FC = () => {
           <Grid item sm={12} lg={6}>
             <Box mt={2} mb={3} px={5} textAlign="center">
               <Typography variant="h6">
-              You are about to see the effects of climate change 
-              and how you can take action against it
+                You are about to see the effects of climate change and how you
+                can take action against it
               </Typography>
             </Box>
           </Grid>


### PR DESCRIPTION
this feature updates `PersonalValuesFeed.tsx` and fixes the issue where the  `ArrowDown` component would show in the same row as the header text in the desktop media query, instead of in a column like the mobile media query.

We discussed if to have the button above the header text, however I decided to keep it underneath it for now, (I'm not sure if this change is wanted 100% yet), (all we need to do if we wanted the arrow above the header is just move the arrow down above the header, still works the same)

I ran all tests and they seem to be fine.