### PR TITLE
CM-365 change in design of pv page

### DIFF
--- a/src/__tests__/src/PersonalValues.test.tsx
+++ b/src/__tests__/src/PersonalValues.test.tsx
@@ -44,7 +44,7 @@ describe('Climate Personality', () => {
     const { getByText } = render(<PersonalValues />);
     expect(
       getByText(
-        /Next Up, I will show you how you can take action against climate change./i
+        /You are about to see the effects of climate change and how you can take action against it/i
       )
     ).toBeInTheDocument();
   });

--- a/src/__tests__/src/PersonalValues.test.tsx
+++ b/src/__tests__/src/PersonalValues.test.tsx
@@ -44,7 +44,7 @@ describe('Climate Personality', () => {
     const { getByText } = render(<PersonalValues />);
     expect(
       getByText(
-        /You are about to see the effects of climate change and how you can take action against it/i
+        /Next Up, I will show you how you can take action against climate change./i
       )
     ).toBeInTheDocument();
   });

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -126,22 +126,6 @@ const PersonalValues: React.FC = () => {
                 </Card>
               ))}
           </Grid>
-
-          {/* <Grid item sm={12} lg={6} container justify="center">
-            <Box mt={6} mb={4} px={2} textAlign="center">
-              <Typography variant="h6">
-                Climate Personality not quite right?
-              </Typography>
-              <Box mt={4}>
-                <Button onClick={handleRetakeQuiz} variant="text">
-                  Retake the Quiz
-                </Button>
-              </Box>
-            </Box>
-            <Box mt={5} mb={3}>
-              <ArrowDown />
-            </Box>
-          </Grid> */}
         </Grid>
 
         <Grid item sm={false} lg={4}>
@@ -201,6 +185,19 @@ const PersonalValues: React.FC = () => {
               </Button>
             </Box>
           </Grid>
+        </Grid>
+
+        <Grid item sm={12} lg={6} container justify="center">
+          <Box mt={6} mb={4} px={2} textAlign="center">
+            <Typography variant="h6">
+              Climate Personality not quite right?
+            </Typography>
+            <Box mt={4}>
+              <Button onClick={handleRetakeQuiz} variant="text">
+                Retake the Quiz
+              </Button>
+            </Box>
+          </Box>
         </Grid>
 
         <Grid item sm={false} lg={4}>

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -26,10 +26,6 @@ const styles = makeStyles({
   typography: {
     textAlign: 'center',
   },
-  grid: {
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
 });
 
 const PersonalValues: React.FC = () => {
@@ -130,6 +126,22 @@ const PersonalValues: React.FC = () => {
                 </Card>
               ))}
           </Grid>
+
+          {/* <Grid item sm={12} lg={6} container justify="center">
+            <Box mt={6} mb={4} px={2} textAlign="center">
+              <Typography variant="h6">
+                Climate Personality not quite right?
+              </Typography>
+              <Box mt={4}>
+                <Button onClick={handleRetakeQuiz} variant="text">
+                  Retake the Quiz
+                </Button>
+              </Box>
+            </Box>
+            <Box mt={5} mb={3}>
+              <ArrowDown />
+            </Box>
+          </Grid> */}
         </Grid>
 
         <Grid item sm={false} lg={4}>
@@ -154,15 +166,10 @@ const PersonalValues: React.FC = () => {
         >
           <Grid item>
             <Box mt={2} mb={4} px={2}>
-              <Grid
-                container
-                direction="column"
-                alignItems="center"
-                spacing={5}
-              >
-                <Box mt={5} mb={3}>
-                  <ArrowDown />
-                </Box>
+              <Grid container direction="row" alignItems="center" spacing={5}>
+                <Grid item xs={3}>
+                  <Logo width="76" data-testid="climate-mind-logo" />
+                </Grid>
                 <Grid item xs={9}>
                   <Typography variant="h4">
                     Ready to dive into Climate Mind?
@@ -175,8 +182,8 @@ const PersonalValues: React.FC = () => {
           <Grid item sm={12} lg={6}>
             <Box mt={2} mb={3} px={5} textAlign="center">
               <Typography variant="h6">
-                You are about to see the effects of climate change and how you
-                can take action against it
+                Next up, I will show you how you can take action against climate
+                change.
               </Typography>
             </Box>
           </Grid>
@@ -192,26 +199,6 @@ const PersonalValues: React.FC = () => {
               >
                 Yes, I’m ready!
               </Button>
-            </Box>
-          </Grid>
-
-          <Grid
-            className={classes.grid}
-            item
-            sm={12}
-            lg={6}
-            container
-            justify="center"
-          >
-            <Box mt={6} mb={4} px={2} textAlign="center">
-              <Typography variant="h6">
-                Climate Personality not quite right?
-              </Typography>
-              <Box mt={4}>
-                <Button onClick={handleRetakeQuiz} variant="text">
-                  Retake the Quiz
-                </Button>
-              </Box>
             </Box>
           </Grid>
         </Grid>

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -29,7 +29,7 @@ const styles = makeStyles({
   grid: {
     flexDirection: 'column',
     alignItems: 'center',
-  }
+  },
 });
 
 const PersonalValues: React.FC = () => {
@@ -130,22 +130,6 @@ const PersonalValues: React.FC = () => {
                 </Card>
               ))}
           </Grid>
-
-          <Grid className={classes.grid} item sm={12} lg={6} container justify="center">
-            <Box mt={6} mb={4} px={2} textAlign="center">
-              <Typography variant="h6">
-                Climate Personality not quite right?
-              </Typography>
-              <Box mt={4}>
-                <Button onClick={handleRetakeQuiz} variant="text">
-                  Retake the Quiz
-                </Button>
-              </Box>
-            </Box>
-            <Box mt={5} mb={3}>
-              <ArrowDown />
-            </Box>
-          </Grid>
         </Grid>
 
         <Grid item sm={false} lg={4}>
@@ -155,7 +139,7 @@ const PersonalValues: React.FC = () => {
 
       {/* Call to action section */}
 
-      <Wrapper bgColor="#FAFF7E" fullHeight={true}>
+      <Wrapper bgColor="#CAF7BC" fullHeight={true}>
         <Grid item sm={false} lg={4}>
           {/* left gutter */}
         </Grid>
@@ -170,10 +154,15 @@ const PersonalValues: React.FC = () => {
         >
           <Grid item>
             <Box mt={2} mb={4} px={2}>
-              <Grid container direction="row" alignItems="center" spacing={5}>
-                <Grid item xs={3}>
-                  <Logo width="76" data-testid="climate-mind-logo" />
-                </Grid>
+              <Grid
+                container
+                direction="column"
+                alignItems="center"
+                spacing={5}
+              >
+                <Box mt={5} mb={3}>
+                  <ArrowDown />
+                </Box>
                 <Grid item xs={9}>
                   <Typography variant="h4">
                     Ready to dive into Climate Mind?
@@ -203,6 +192,26 @@ const PersonalValues: React.FC = () => {
               >
                 Yes, I’m ready!
               </Button>
+            </Box>
+          </Grid>
+
+          <Grid
+            className={classes.grid}
+            item
+            sm={12}
+            lg={6}
+            container
+            justify="center"
+          >
+            <Box mt={6} mb={4} px={2} textAlign="center">
+              <Typography variant="h6">
+                Climate Personality not quite right?
+              </Typography>
+              <Box mt={4}>
+                <Button onClick={handleRetakeQuiz} variant="text">
+                  Retake the Quiz
+                </Button>
+              </Box>
             </Box>
           </Grid>
         </Grid>

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -153,8 +153,15 @@ const PersonalValues: React.FC = () => {
         >
           <Grid item>
             <Box mt={2} mb={4} px={2}>
-              <Grid className={classes.arrowContainer} item xs={3}>
-                <ArrowDown width="100px" height="100px" />
+              <Grid
+                container
+                justify="center"
+                alignItems="center"
+                className={classes.arrowContainer}
+                item
+                xs={3}
+              >
+                <ArrowDown width="90px" height="90px" />
               </Grid>
               <Grid container direction="row" alignItems="center" spacing={5}>
                 <Grid item xs={3}>

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -26,6 +26,9 @@ const styles = makeStyles({
   typography: {
     textAlign: 'center',
   },
+  arrowContainer: {
+    margin: '0 auto',
+  },
 });
 
 const PersonalValues: React.FC = () => {
@@ -150,6 +153,9 @@ const PersonalValues: React.FC = () => {
         >
           <Grid item>
             <Box mt={2} mb={4} px={2}>
+              <Grid className={classes.arrowContainer} item xs={3}>
+                <ArrowDown width="100px" height="100px" />
+              </Grid>
               <Grid container direction="row" alignItems="center" spacing={5}>
                 <Grid item xs={3}>
                   <Logo width="76" data-testid="climate-mind-logo" />

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -176,7 +176,7 @@ const PersonalValues: React.FC = () => {
             </Box>
           </Grid>
 
-          <Grid item sm={12} lg={6}>
+          <Grid item xs={12} sm={8} md={6} lg={9}>
             <Box mt={2} mb={3} px={5} textAlign="center">
               <Typography variant="h6">
                 You are about to see the effects of climate change and how you

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -179,8 +179,8 @@ const PersonalValues: React.FC = () => {
           <Grid item sm={12} lg={6}>
             <Box mt={2} mb={3} px={5} textAlign="center">
               <Typography variant="h6">
-                Next up, I will show you how you can take action against climate
-                change.
+                You are about to see the effects of climate change and how you
+                can take action against it
               </Typography>
             </Box>
           </Grid>


### PR DESCRIPTION
This feature updates `PersonalValuesFeed.tsx` to match the design provided at: https://xd.adobe.com/view/c23372e2-dc1f-4bfb-806d-a0220509874f-9760/screen/4e0b28b1-9fb2-4815-abf7-bcbf6c71954c/
<img width="410" alt="Screen Shot 2021-01-11 at 12 13 51 AM" src="https://user-images.githubusercontent.com/59632599/104148853-f4fd1980-53a1-11eb-8861-901319652b61.png">

it doesn't change the text. as requested.
