### PR TITLE
CM-362 local impacts display incorrectly

### DIFF
--- a/src/__tests__/src/__components__/CardHeader.test.tsx
+++ b/src/__tests__/src/__components__/CardHeader.test.tsx
@@ -31,8 +31,7 @@ describe('It renders the title', () => {
         title="Card Title"
         index={1}
         bgColor="red"
-        cardIcon="prevention"
-        isPossiblyLocal={true}
+        isPossiblyLocal={1}
       />
     );
     expect(getByTestId('LocalIcon')).toBeInTheDocument();

--- a/src/components/CardHeader.tsx
+++ b/src/components/CardHeader.tsx
@@ -13,7 +13,7 @@ export interface CardHeaderProps {
   bgColor?: string;
   preTitle?: string;
   preTitleStyle?: 'positive' | 'warning';
-  isPossiblyLocal?: boolean;
+  isPossiblyLocal?: 0 | 1;
 }
 
 const CardHeader: React.FC<CardHeaderProps> = ({
@@ -101,42 +101,38 @@ const CardHeader: React.FC<CardHeaderProps> = ({
           </Grid>
         )}
         <Grid item xs={10} container>
-            {preTitle && (
-              <Grid item xs={10} container alignItems="center">
-                {isPossiblyLocal && <Grid
+          {preTitle && (
+            <Grid item xs={10} container alignItems="center">
+              {isPossiblyLocal === 1 && (
+                <Grid
                   item
                   xs={1}
                   className={classes.preTitleIcon}
                   data-testid="LocalIcon"
-                  >
-                    <RoomIcon style={ preIconStyles }/>
-                </Grid>}
-                <Grid
-                  item
-                  xs={9}
-                  data-testid="PreTitle"
-                  >
-                    <Typography
-                    className={classes.preTitle}
-                    gutterBottom
-                    variant="h3"
-                    component="h3"
-                  >
-                    {preTitle}
-                  </Typography>
+                >
+                  <RoomIcon style={preIconStyles} />
                 </Grid>
+              )}
+              <Grid item xs={9} data-testid="PreTitle">
+                <Typography
+                  className={classes.preTitle}
+                  gutterBottom
+                  variant="h3"
+                  component="h3"
+                >
+                  {preTitle}
+                </Typography>
               </Grid>
-                  
-              
-            )}
-            <Typography
-              className={classes.title}
-              gutterBottom
-              variant="h6"
-              component="h2"
-            >
-              {title}
-            </Typography>
+            </Grid>
+          )}
+          <Typography
+            className={classes.title}
+            gutterBottom
+            variant="h6"
+            component="h2"
+          >
+            {title}
+          </Typography>
         </Grid>
       </Grid>
     </div>

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -91,7 +91,9 @@ const ClimateFeed: React.FC = () => {
                       header={
                         <CardHeader
                           title={effect.effectTitle}
-                          preTitle={'Local impact'}
+                          preTitle={
+                            effect?.isPossiblyLocal ? 'Local impact' : ''
+                          }
                           isPossiblyLocal={effect.isPossiblyLocal}
                         />
                       }

--- a/src/stories/components/CardHeadline.stories.tsx
+++ b/src/stories/components/CardHeadline.stories.tsx
@@ -45,7 +45,7 @@ export const WithIsLocal = Template.bind({});
 WithIsLocal.args = {
   ...Default.args,
   preTitle: 'Pre-title',
-  isPossiblyLocal: true
+  isPossiblyLocal: 1,
 };
 
 export const NumberCards = Template.bind({});

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -54,7 +54,7 @@ export type TClimateEffect = {
   // effectScore: number;
   imageUrl: string;
   actionHeadline: string;
-  isPossiblyLocal: boolean;
+  isPossiblyLocal: 0 | 1;
 };
 
 // export type TPersonalValues = [TPersonalValue];


### PR DESCRIPTION
Backend changed `isPossiblyLocal` from being a boolean to either 0 or 1.

- Updated types and conditional check to display the icon. 
- Added a conditional to make sure "Local Effect" pretitle is only show when there `isLocal === 1`

<img width="418" alt="Screenshot 2021-01-11 at 23 31 48" src="https://user-images.githubusercontent.com/44759513/104250545-b761c480-5465-11eb-8a38-eca374df81fb.png">
<img width="447" alt="Screenshot 2021-01-11 at 23 29 44" src="https://user-images.githubusercontent.com/44759513/104250549-b9c41e80-5465-11eb-939e-095d578a0bb0.png">


