### PR TITLE
CM-382 remove short desc from overlays & add link to conversations

### DIFF
--- a/src/components/ActionOverlay.tsx
+++ b/src/components/ActionOverlay.tsx
@@ -12,15 +12,13 @@ export interface ActionOverlayProps {
 }
 
 interface DetailsProps {
-  shortDescription: string;
   longDescription: string;
 }
 
 // Stuff to pass into the details Tab
-const Details = ({ shortDescription, longDescription }: DetailsProps) => (
+const Details = ({ longDescription }: DetailsProps) => (
   <>
     <Box p={3}>
-      <Typography variant="body1">{shortDescription}</Typography>
       <Typography variant="body1">{longDescription}</Typography>
     </Box>
   </>
@@ -50,12 +48,7 @@ const ActionOverlay: React.FC<ActionOverlayProps> = ({ action }) => {
     >
       <ActionTabbedContent
         action={action}
-        details={
-          <Details
-            shortDescription={action.shortDescription}
-            longDescription={action.longDescription}
-          />
-        }
+        details={<Details longDescription={action.longDescription} />}
         sources={<SourcesList sources={solutionSources} />} // Sources to come later
       />
     </CardOverlay>

--- a/src/components/EffectOverlay.tsx
+++ b/src/components/EffectOverlay.tsx
@@ -13,7 +13,6 @@ import MythCard from './MythCard';
 import { useAssociatedMyths } from '../hooks/useAssociatedMyths';
 
 interface DetailsProps {
-  shortDescription: string;
   longDescription: string;
   solutions: TActionNodeList;
   associatedMyths: any;
@@ -21,14 +20,12 @@ interface DetailsProps {
 
 // Stuff to pass into the details Tab
 const Details = ({
-  shortDescription,
   longDescription,
   solutions,
   associatedMyths,
 }: DetailsProps) => (
   <>
     <Box p={3}>
-      <Typography variant="body1">{shortDescription}</Typography>
       <Typography variant="body1">{longDescription}</Typography>
     </Box>
     <ActionNodeList nodes={solutions} />
@@ -46,7 +43,6 @@ const EffectOverlay: React.FC<EffectOverlayProps> = ({ effect }) => {
   const {
     effectTitle,
     effectDescription,
-    effectShortDescription,
     imageUrl,
     effectSolutions,
     effectSources,
@@ -65,7 +61,6 @@ const EffectOverlay: React.FC<EffectOverlayProps> = ({ effect }) => {
       <TabbedContent
         details={
           <Details
-            shortDescription={effectShortDescription}
             longDescription={effectDescription}
             solutions={effectSolutions}
             associatedMyths={associatedMyths}

--- a/src/components/SolutionOverlay.tsx
+++ b/src/components/SolutionOverlay.tsx
@@ -23,7 +23,6 @@ export interface SolutionOverlayProps {
 const Details = ({ solution, associatedMyths }: DetailsProps) => (
   <>
     <Box p={3}>
-      <Typography variant="body1">{solution.shortDescription}</Typography>
       <Typography variant="body1">{solution.longDescription}</Typography>
     </Box>
     {associatedMyths?.map((item: { data: { myth: TMyth } }, i: number) => (

--- a/src/pages/Conversations.tsx
+++ b/src/pages/Conversations.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   makeStyles,
   createStyles,
+  Link,
 } from '@material-ui/core';
 import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import Wrapper from '../components/Wrapper';
@@ -28,6 +29,10 @@ const useStyles = makeStyles(() =>
       '& svg': {
         height: '50px',
       },
+    },
+    link: {
+      color: COLORS.DK_TEXT,
+      textDecoration: 'underline',
     },
   })
 );
@@ -95,9 +100,18 @@ const ConversationsPage: React.FC = () => {
 
           <Grid>
             <Typography variant="body1" component="p" align="center">
-              Check out climatemind.org if you are interested in helping out.
-              Any questions or feedback? Drop us an email at
-              hello@climatemind.org
+              Check out{' '}
+              <Link className={classes.link} href="http://www.climatemind.org">
+                climatemind.org
+              </Link>{' '}
+              if you are interested in helping out. Any questions or feedback?
+              Drop us an email at{' '}
+              <Link
+                className={classes.link}
+                href="mailto:hello@climatemind.org"
+              >
+                hello@climatemind.org
+              </Link>
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
# remove short desc from overlays & add link to conversations

This card resolves [CM-382 Remove short description from all overlays](https://climatemind.atlassian.net/browse/CM-382) and [CM-395 - Add hyperlink to text in Conversations](https://climatemind.atlassian.net/browse/CM-395)

