### PR TITLE
CM-425 remove quatation marks from myths

### DIFF
--- a/src/components/MythHeader.tsx
+++ b/src/components/MythHeader.tsx
@@ -57,7 +57,7 @@ const MythHeader: React.FC<MythHeaderProps> = ({
           variant="h6"
           component="h2"
         >
-          “{capitalizeFirstLetter(mythRebuttal)}
+          {capitalizeFirstLetter(mythRebuttal)}
         </Typography>
       </Box>
 
@@ -77,7 +77,7 @@ const MythHeader: React.FC<MythHeaderProps> = ({
           variant="h6"
           component="h2"
         >
-          “{capitalizeFirstLetter(mythTitle)}”
+          {capitalizeFirstLetter(mythTitle)}
         </Typography>
       </Box>
     </>

--- a/src/components/MythHeader.tsx
+++ b/src/components/MythHeader.tsx
@@ -57,7 +57,7 @@ const MythHeader: React.FC<MythHeaderProps> = ({
           variant="h6"
           component="h2"
         >
-          {capitalizeFirstLetter(mythRebuttal)}
+          <em>{capitalizeFirstLetter(mythRebuttal)}</em>
         </Typography>
       </Box>
 
@@ -77,7 +77,7 @@ const MythHeader: React.FC<MythHeaderProps> = ({
           variant="h6"
           component="h2"
         >
-          {capitalizeFirstLetter(mythTitle)}
+          <em>{capitalizeFirstLetter(mythTitle)}</em>
         </Typography>
       </Box>
     </>

--- a/src/components/MythHeader.tsx
+++ b/src/components/MythHeader.tsx
@@ -57,7 +57,7 @@ const MythHeader: React.FC<MythHeaderProps> = ({
           variant="h6"
           component="h2"
         >
-          <em>{capitalizeFirstLetter(mythRebuttal)}</em>
+          {capitalizeFirstLetter(mythRebuttal)}
         </Typography>
       </Box>
 


### PR DESCRIPTION
This feature updates `MythHeader.tsx` and removes the quotation marks from myths and truths, and indents the text instead.