### PR TITLE
Mon various visual tweaks

### DIFF
--- a/cypress/integration/climatefeed.spec.ts
+++ b/cypress/integration/climatefeed.spec.ts
@@ -46,7 +46,7 @@ describe('Climate Feed loads and looks correct', () => {
   });
 
   it('User is redirected to the feed when they click get started AND feed has the correct number of cards', () => {
-    cy.contains('Climate').should('be.visible');
+    cy.contains('Catalyzing climate action').should('be.visible');
     cy.contains('Get Started').click();
     cy.contains('Your Personal Climate Feed').click();
     cy.get('[data-testid="CMCard"]').should('have.length', 21);

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -97,27 +97,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
             <div className={classes.offset} />
 
             <Grid item>
-              {/* Menu List Items */}
               <List>
-                {menuLinks.map((item, index) => (
-                  <ListItem
-                    button
-                    key={index}
-                    disableGutters={false}
-                    onClick={() => handleNavAway(item.url)}
-                  >
-                    <ListItemText primary={item.text} />
-                  </ListItem>
-                ))}
-                {/* Privacy Policy */}
-                <ListItem
-                  button
-                  disableGutters={false}
-                  onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
-                >
-                  <ListItemText primary="Privacy Policy" />
-                </ListItem>
-
                 {/* Personal Values option should only show if there is a session id */}
                 {sessionId && (
                   <>
@@ -137,6 +117,26 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                     </ListItem>
                   </>
                 )}
+
+                {/* Menu List Items */}
+                {menuLinks.map((item, index) => (
+                  <ListItem
+                    button
+                    key={index}
+                    disableGutters={false}
+                    onClick={() => handleNavAway(item.url)}
+                  >
+                    <ListItemText primary={item.text} />
+                  </ListItem>
+                ))}
+                {/* Privacy Policy */}
+                <ListItem
+                  button
+                  disableGutters={false}
+                  onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
+                >
+                  <ListItemText primary="Privacy Policy" />
+                </ListItem>
               </List>
             </Grid>
 

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -118,7 +118,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                   </>
                 )}
 
-                {/* Menu List Items */}
+                {/* Menu List Items  */}
                 {menuLinks.map((item, index) => (
                   <ListItem
                     button

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -41,7 +41,7 @@ const menuLinks = [
   { text: 'About ClimateMind', url: 'https://climatemind.org/' },
   { text: 'Scientists Speak Up', url: 'https://scientistsspeakup.org/' },
   {
-    text: "What's an Ontology",
+    text: "What's an Ontology?",
     url:
       'https://docs.google.com/document/d/16Ot_5WPNOLUIrLkmusbMVnN827OEJKigrT2B8HP--Jk/edit#heading=h.3dxiw2n8d0ml',
   },

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
       height: '100%',
     },
     menuEmail: {
-      padding: theme.spacing(2),
+      // padding: theme.spacing(2),
       marginTop: '1em',
     },
     offset: theme.mixins.toolbar,
@@ -103,14 +103,14 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                   <>
                     <ListItem
                       button
-                      disableGutters={false}
+                      disableGutters={true}
                       onClick={() => handleNav(ROUTES.ROUTE_VALUES)}
                     >
                       <ListItemText primary="Personal Values" />
                     </ListItem>
                     <ListItem
                       button
-                      disableGutters={false}
+                      disableGutters={true}
                       onClick={handleRetakeQuiz}
                     >
                       <ListItemText primary="Re-take the Quiz" />
@@ -123,7 +123,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                   <ListItem
                     button
                     key={index}
-                    disableGutters={false}
+                    disableGutters={true}
                     onClick={() => handleNavAway(item.url)}
                   >
                     <ListItemText primary={item.text} />
@@ -132,7 +132,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                 {/* Privacy Policy */}
                 <ListItem
                   button
-                  disableGutters={false}
+                  disableGutters={true}
                   onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
                 >
                   <ListItemText primary="Privacy Policy" />

--- a/src/components/AppBar/Socials.tsx
+++ b/src/components/AppBar/Socials.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles(() =>
   createStyles({
     menuSocials: {
       marginTop: '8vh',
+      marginLeft: -12,
       maxWidth: '220px',
     },
     faIcon: {

--- a/src/components/CardHeader.tsx
+++ b/src/components/CardHeader.tsx
@@ -71,8 +71,11 @@ const CardHeader: React.FC<CardHeaderProps> = ({
         marginBottom: '-10px',
       },
       title: {
-        textTransform: 'capitalize',
+        // textTransform: 'capitalize',
         margin: 0,
+        '&::first-letter': {
+          textTransform: 'capitalize',
+        },
       },
     })
   );

--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -87,9 +87,16 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
         margin: 0,
         paddingTop: '56.25%',
       },
+      closeArea: {
+        '& p': {
+          fonstSize: '12px',
+        },
+      },
       arrow: {
+        width: '32px',
+        height: '32px',
         padding: 0,
-        marginTop: '-7px',
+        marginTop: '-20px',
       },
     })
   );
@@ -128,8 +135,12 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
                 alignItems="center"
                 justify="space-between"
               >
-                <Grid item>
-                  <Typography variant="body1" component="p">
+                <Grid item className={classes.closeArea}>
+                  <Typography
+                    onClick={handleShowMoreClick}
+                    variant="body1"
+                    component="p"
+                  >
                     Close
                   </Typography>
                 </Grid>

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -87,7 +87,10 @@ const ClimateFeed: React.FC = () => {
                 {data.climateEffects.map((effect, i) => {
                   const preview = effect.effectSolutions[0];
                   return (
-                    <div data-testid={`EffectCard-${effect.effectId}`}>
+                    <div
+                      data-testid={`EffectCard-${effect.effectId}`}
+                      key={`value-${i}`}
+                    >
                       <Card
                         header={
                           <CardHeader
@@ -98,7 +101,6 @@ const ClimateFeed: React.FC = () => {
                             isPossiblyLocal={effect.isPossiblyLocal}
                           />
                         }
-                        key={`value-${i}`}
                         index={i}
                         imageUrl={effect.imageUrl}
                         footer={<EffectOverlay effect={effect} />}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -40,7 +40,7 @@ const Home: React.FC<{}> = () => {
             align="center"
             className={classes.typography}
           >
-            Catalyzing Climate Action (Beta)
+            Catalyzing climate action (beta)
           </Typography>
         </Box>
       </Grid>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -40,7 +40,7 @@ const Home: React.FC<{}> = () => {
             align="center"
             className={classes.typography}
           >
-            Catalyzing Climate Action
+            Catalyzing climate action
           </Typography>
         </Box>
       </Grid>

--- a/src/pages/MeetGuy.tsx
+++ b/src/pages/MeetGuy.tsx
@@ -44,7 +44,7 @@ const MeetGuy: React.FC<{}> = () => {
         <Box px={5}>
           <Typography className={classes.typography}>
             I’ll help you find out your Climate Personality to give you
-            personalised solutions to climate change.
+            personalized solutions to climate change.
           </Typography>
         </Box>
       </Grid>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -32,7 +32,7 @@ const PrivacyPolicy: React.FC = () => {
       data-testid="Privacy Policy"
       justify="space-around"
     >
-      <Wrapper bgColor={COLORS.ACCENT4}>
+      <Wrapper bgColor={COLORS.PRIMARY}>
         <Grid item sm={false} lg={4}>
           {/* left gutter */}
         </Grid>

--- a/src/pages/Questionnaire.tsx
+++ b/src/pages/Questionnaire.tsx
@@ -68,13 +68,7 @@ const Questionaire: React.FC<{}> = () => {
           </Box>
         </Grid>
 
-        <Grid
-          item
-          className={classes.progressBarContainer}
-          direction="column"
-          justify="space-between"
-          alignItems="flex-start"
-        >
+        <Grid item className={classes.progressBarContainer}>
           <LinearProgress
             aria-label="Questionnaire Progress"
             className={classes.progressBar}


### PR DESCRIPTION
Went through Kay's bug list and tried to squash as many simple ones as possible. 

**Titles for feed and solutions being title-case CM-413**

<img width="399" alt="CM-413 titles for feed" src="https://user-images.githubusercontent.com/44759513/104937861-2f6c4500-59a6-11eb-82eb-399ad0af91c5.png">

**Close button is too big and too spaced apart on Overlay CM-420**

<img width="399" alt="CM-420 close button too big" src="https://user-images.githubusercontent.com/44759513/104937907-3eeb8e00-59a6-11eb-80a0-43b9f8804bb5.png">

**hamburger menu - link list should be reordered. CM-434 and CM-433** 
Also fixed padding
<img width="396" alt="Screenshot 2021-01-18 at 15 55 55" src="https://user-images.githubusercontent.com/44759513/104937954-53c82180-59a6-11eb-8546-9df9e3bbc6bb.png">

**Americanise “...personalized solutions... “ on 1st orange screen CM-408**

<img width="400" alt="CM-408 amrican spelling of Personalized" src="https://user-images.githubusercontent.com/44759513/104938100-82de9300-59a6-11eb-942a-69447e0346d8.png">

**Catalyzing Climate Action shouldn't be capitalised. CM-406**

<img width="401" alt="Screenshot 2021-01-18 at 15 38 01" src="https://user-images.githubusercontent.com/44759513/104938165-97bb2680-59a6-11eb-813a-c2032c0f711a.png">

**Privacy Policy should have a white background colour CM-437**
<img width="402" alt="CM-437 Privacty Policy White BG" src="https://user-images.githubusercontent.com/44759513/104938221-ae617d80-59a6-11eb-8f11-4b87a1bc1148.png">






