### PR TITLE
CM-323 add quiz completion to data layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1290,6 +1290,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "@cypress/xvfb": {
@@ -6329,6 +6337,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
       "dev": true
     },
     "@types/webpack": {
@@ -16975,6 +16989,12 @@
             "ansi-regex": "^5.0.0"
           }
         },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -17053,8 +17073,7 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -21050,6 +21069,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "request-progress": {
@@ -21936,6 +21962,13 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "sockjs-client": {
@@ -23668,9 +23701,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",
@@ -24454,6 +24487,13 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@types/react-gtm-module": "^2.0.0",
     "@types/react-router-dom": "^5.1.5",
     "clsx": "^1.1.1",
+    "moment": "^2.29.1",
     "react": "^16.13.1",
     "react-div-100vh": "^0.5.6",
     "react-dom": "^16.13.1",
@@ -15,7 +16,8 @@
     "react-query": "^3.5.5",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.0",
-    "sinon": "^9.2.2"
+    "sinon": "^9.2.2",
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -65,6 +67,7 @@
     "@types/node": "^12.12.50",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.6.1",
     "@typescript-eslint/parser": "^3.6.1",
     "cypress": "^5.1.0",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -11,8 +11,8 @@ export const pushQuizStartToDataLayer = (quizSessionId: string): void  => {
       event: 'event',
       eventProps: {
         category: 'questionnaire',
-        action: 'quiz_start',
-        label: 'quiz_session_id',
+        action: 'questionnaire_start',
+        label: 'questionnaire_session_id',
         value: quizSessionId,
         event_ts: makeDate(),
       }
@@ -26,9 +26,10 @@ export const pushQuizFinishToDataLayer = (quizSessionId: string, sessionId: stri
       event: 'event',
       eventProps: {
         category: 'questionnaire',
-        action: 'quiz_finish',
-        label: 'quiz_complete',
-        value: {quizSessionId, sessionId},
+        action: 'questionnaire_finish',
+        label: 'questionnaire_session_id',
+        value: quizSessionId,
+        session_id: sessionId,
         event_ts: makeDate(),
       }
     },
@@ -43,9 +44,10 @@ export const pushQuestionToDataLayer = (questionId: number, quizSessionId:string
       event: 'event',
       eventProps: {
         category: 'questionnaire',
-        action: 'question_start',
-        label: 'question',
-        value: {questionId, quizSessionId},
+        action: 'question_loaded',
+        label: 'question_id',
+        value: questionId, 
+        quiz_session_id: quizSessionId,
         event_ts: makeDate()
       }
     },
@@ -60,7 +62,7 @@ export const addCardClickToDataLayer =
         event: 'event',
         eventProps: {
           category: 'card',
-          action: 'card_click',
+          action: 'card_open',
           label: 'card_iri',
           value: iri,
           session_id: sessionId,

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -6,7 +6,6 @@ const makeDate = () => moment(new Date().toISOString()).format('YYYY-MM-DD HH:mm
 
 
 export const pushQuizStartToDataLayer = (quizSessionId: string): void  => {
-  console.log('Quiz Start to DL', quizSessionId)
   TagManager.dataLayer({
     dataLayer: {
       event: 'event',
@@ -22,7 +21,6 @@ export const pushQuizStartToDataLayer = (quizSessionId: string): void  => {
 };
 
 export const pushQuizFinishToDataLayer = (quizSessionId: string, sessionId: string): void => {
-  console.log('Quiz Submit to DL', sessionId, quizSessionId)
   TagManager.dataLayer({
     dataLayer: {
       event: 'event',
@@ -40,7 +38,6 @@ export const pushQuizFinishToDataLayer = (quizSessionId: string, sessionId: stri
 
 // This has been added to the prettier ignore file as tag manager does not pick up events when trailing commas are added to the data layer object
 export const pushQuestionToDataLayer = (questionId: number, quizSessionId:string): void  => {
-  console.log('Question to DL', quizSessionId, quizSessionId)
   TagManager.dataLayer({
     dataLayer: {
       event: 'event',

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,16 +1,55 @@
 import TagManager from 'react-gtm-module';
+import moment from 'moment';
+
+
+const makeDate = () => moment(new Date().toISOString()).format('YYYY-MM-DD HH:mm:ss');
+
+
+export const pushQuizStartToDataLayer = (quizSessionId: string): void  => {
+  console.log('Quiz Start to DL', quizSessionId)
+  TagManager.dataLayer({
+    dataLayer: {
+      event: 'event',
+      eventProps: {
+        category: 'questionnaire',
+        action: 'quiz_start',
+        label: 'quiz_session_id',
+        value: quizSessionId,
+        event_ts: makeDate(),
+      }
+    },
+  });
+};
+
+export const pushQuizFinishToDataLayer = (quizSessionId: string, sessionId: string): void => {
+  console.log('Quiz Submit to DL', sessionId, quizSessionId)
+  TagManager.dataLayer({
+    dataLayer: {
+      event: 'event',
+      eventProps: {
+        category: 'questionnaire',
+        action: 'quiz_finish',
+        label: 'quiz_complete',
+        value: {quizSessionId, sessionId},
+        event_ts: makeDate(),
+      }
+    },
+  });
+};
+
 
 // This has been added to the prettier ignore file as tag manager does not pick up events when trailing commas are added to the data layer object
-export const pushQuestionToDataLayer = (questionId: number): void  => {
+export const pushQuestionToDataLayer = (questionId: number, quizSessionId:string): void  => {
+  console.log('Question to DL', quizSessionId, quizSessionId)
   TagManager.dataLayer({
     dataLayer: {
       event: 'event',
       eventProps: {
         category: 'questionnaire',
         action: 'question_start',
-        label: 'question_id',
-        value: questionId,
-        event_ts: new Date().toISOString().slice(0, 19).replace('T', ' ')
+        label: 'question',
+        value: {questionId, quizSessionId},
+        event_ts: makeDate()
       }
     },
   });
@@ -28,7 +67,7 @@ export const addCardClickToDataLayer =
           label: 'card_iri',
           value: iri,
           session_id: sessionId,
-          event_ts: new Date().toISOString().slice(0, 19).replace('T', ' ')
+          event_ts: makeDate()
         }
       },
     });

--- a/src/api/postScores.ts
+++ b/src/api/postScores.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { pushQuizFinishToDataLayer } from '../analytics';
 import { TResponse } from '../types/types';
 import { buildUrl } from './apiHelper';
 
@@ -11,16 +12,21 @@ type TErrorResponse = {
   sessionId: null;
 };
 
+type Scores = {
+  SetOne: TResponse[];
+  zipCode: string | null;
+};
+
 export async function submitScores(
-  SetOne: TResponse[],
-  zipCode: string | null
+  scores: Scores,
+  quizSessionId: string
 ): Promise<TScoreSubmitResponse | TErrorResponse> {
   // Request body for Submission
   const REQUEST_BODY = {
     questionResponses: {
-      SetOne: [...SetOne],
+      SetOne: [...scores.SetOne],
     },
-    zipCode,
+    zipCode: scores.zipCode,
   };
 
   // Build the correct url
@@ -30,7 +36,8 @@ export async function submitScores(
   // Try and make the request
   try {
     const response = await axios.post(REQUEST_URL, REQUEST_BODY);
-    const data = response.data;
+    const data = await response.data;
+    pushQuizFinishToDataLayer(data.sessionId, quizSessionId);
     return data;
   } catch (err) {
     console.error(err);

--- a/src/contexts/session.tsx
+++ b/src/contexts/session.tsx
@@ -15,6 +15,7 @@ export const SessionProvider: React.FC = ({ children }) => {
 
   const [session, setSession] = useState<TSession>({
     sessionId: null,
+    quizSessionId: null,
     zipCode: null,
     hasAcceptedCookies,
     setHasAcceptedCookies,

--- a/src/contexts/session.tsx
+++ b/src/contexts/session.tsx
@@ -21,7 +21,7 @@ export const SessionProvider: React.FC = ({ children }) => {
     setHasAcceptedCookies,
   });
 
-  // Updated stats when localSotrage is updated for hasAcceptedCookies
+  // Updated state when localStorage is updated for hasAcceptedCookies
   useEffect(() => {
     setSession((prevState) => ({
       ...prevState,

--- a/src/hooks/useQuiz.tsx
+++ b/src/hooks/useQuiz.tsx
@@ -5,9 +5,13 @@ import { useResponses } from '../hooks/useResponses';
 import { TQuestion } from '../types/types';
 import { pushQuestionToDataLayer } from '../analytics';
 import { useHistory } from 'react-router-dom';
+import { useSession } from '../hooks/useSession';
+import { v4 as uuid } from 'uuid';
+import { pushQuizStartToDataLayer } from '../analytics';
 
 export const useQuiz = () => {
   const { push } = useHistory();
+  const { quizSessionId, setQuizSessionId } = useSession();
 
   const { questions, questionsLoading, questionsError } = useQuestions();
   const [answers, setAnswers] = useState<TAnswers | null>(null);
@@ -73,6 +77,15 @@ export const useQuiz = () => {
     changeQuestionForward();
   };
 
+  // Set the quizSessionId if there isn't one
+  useEffect(() => {
+    if (!quizSessionId) {
+      const newQuizSessionId = uuid();
+      setQuizSessionId(newQuizSessionId);
+      pushQuizStartToDataLayer(newQuizSessionId);
+    }
+  }, [quizSessionId, setQuizSessionId]);
+
   // Setting the questions on load;
   useEffect(() => {
     // TODO - For just now we are only using SetOne
@@ -106,10 +119,10 @@ export const useQuiz = () => {
 
   // add question id to url (for tracking)
   useEffect(() => {
-    if (currentQuestion) {
-      pushQuestionToDataLayer(currentQuestion.id);
+    if (currentQuestion && quizSessionId) {
+      pushQuestionToDataLayer(currentQuestion.id, quizSessionId);
     }
-  }, [currentQuestion]);
+  }, [currentQuestion, quizSessionId]);
 
   return {
     currentQuestion,

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -24,6 +24,7 @@ export const useSession = () => {
         ...session,
         sessionId: localSessionId,
         zipCode: null,
+        quizSessionId: null,
       });
     }
   };
@@ -47,14 +48,14 @@ export const useSession = () => {
     }
   };
 
-  // const setHasAcceptedCookies = (hasAccepted: boolean) => {
-  //   if (setSession) {
-  //     setSession({
-  //       ...session,
-  //       hasAcceptedCookies: hasAccepted,
-  //     });
-  //   }
-  // };
+  const setQuizSessionId = (quizSessionId: string) => {
+    if (setSession) {
+      setSession({
+        ...session,
+        quizSessionId,
+      });
+    }
+  };
 
   useEffect(() => {
     if (setSession) {
@@ -71,6 +72,7 @@ export const useSession = () => {
     setSessionId,
     setZipCode,
     clearSession,
+    setQuizSessionId,
     hasAcceptedCookies,
     setHasAcceptedCookies,
   };

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -11,6 +11,7 @@ export const useSession = () => {
     zipCode,
     hasAcceptedCookies,
     setHasAcceptedCookies,
+    quizSessionId,
   } = session;
 
   const [localSessionId, setLocalSessionId] = useLocalStorage('sessionId', '');
@@ -72,6 +73,7 @@ export const useSession = () => {
     setSessionId,
     setZipCode,
     clearSession,
+    quizSessionId,
     setQuizSessionId,
     hasAcceptedCookies,
     setHasAcceptedCookies,

--- a/src/pages/SubmitQuestionnaire.tsx
+++ b/src/pages/SubmitQuestionnaire.tsx
@@ -15,23 +15,25 @@ import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 const SubmitQuestionnaire: React.FC<{}> = () => {
   const history = useHistory();
   const quizResponses = useResponsesData();
-  const { setSessionId, zipCode } = useSession();
+  const { setSessionId, zipCode, quizSessionId } = useSession();
   const { setPersonalValuesError } = useClimatePersonality();
 
   const handleSubmit = async () => {
     // Submit my scores
-    const SetOne = quizResponses.SetOne;
-    const response = await submitScores(SetOne, zipCode);
-    // Set the Session id
-    if (response && response.sessionId && setSessionId) {
-      const sessionId = response.sessionId;
-      setSessionId(sessionId);
-    } else {
-      setPersonalValuesError();
-      // throw new Error('Failed to submit scores');
+    if (quizSessionId) {
+      const SetOne = quizResponses.SetOne;
+      const response = await submitScores({ SetOne, zipCode }, quizSessionId);
+      // Set the Session id
+      if (response && response.sessionId && setSessionId) {
+        const sessionId = response.sessionId;
+        setSessionId(sessionId);
+      } else {
+        setPersonalValuesError();
+        // throw new Error('Failed to submit scores');
+      }
+      // Navigate to the climate personality page
+      history.push(ROUTES.ROUTE_VALUES);
     }
-    // Navigate to the climate personality page
-    history.push(ROUTES.ROUTE_VALUES);
   };
 
   return (

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -1,5 +1,6 @@
 export type TSession = {
   sessionId: string | null;
+  quizSessionId: string | null;
   zipCode: string | null;
   hasAcceptedCookies: boolean;
   setHasAcceptedCookies: (hasAcceptedCookies: boolean) => any;


### PR DESCRIPTION
This PR is to allow analysts to track the number of users not completing the quiz. 

- Add a quizSessionId (uuid) to the session provider which is generated every time the quiz is started. 
- push this  quiz session id to the Data layer when the quiz is started
- push the quizSession Id along with the question when each question is answered