### PR TITLE
One line change in card overlay to fix misaligned button

### DIFF
--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -73,7 +73,6 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
         marginBottom: '-0.5em',
         fontSize: '11pt',
         letterSpacing: '1pt',
-        paddingLeft: 0,
       },
       titleText: {
         textTransform: 'capitalize',


### PR DESCRIPTION
It's only a one line change removing a padding: 0 for the button.