### PR TITLE
Cm 466 zip code after personal values results

### DIFF
--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -36,8 +36,6 @@ describe('Personal values page loads and looks correct', () => {
       cy.contains('Very Much Like Me').click();
       i++;
     }
-    cy.get('[id=zipCodeInput]').type('90210');
-    cy.get('[id=submitButton]').click();
     cy.url().should('include', '/submit');
     cy.get('[id=submitButton]').click();
     cy.contains('This is your Climate Personality').should('be.visible');
@@ -60,9 +58,11 @@ describe('Personal values page loads and looks correct', () => {
     cy.percySnapshot('Personal Values');
     cy.contains('Ready to dive into Climate Mind?').should('be.visible');
     cy.contains('Yes, I’m ready!').should('be.visible').click();
-    cy.url().should('include', '/climate-feed');
-
+    cy.url().should('include', '/set-location');
+    cy.get('[id=zipCodeInput]').type('90210');
+    cy.get('[id=submitButton]').click();
     // Retake the quiz
+    cy.go('back');
     cy.go('back');
     cy.contains('Climate Personality not quite right?').should('be.visible');
     cy.contains('Retake the Quiz').should('be.visible').click();

--- a/cypress/integration/questionnaire.spec.ts
+++ b/cypress/integration/questionnaire.spec.ts
@@ -44,7 +44,7 @@ describe('Questionnaire loads and looks correct', () => {
         const nextQuestion =
           question < 10
             ? `Q${question + 1}`
-            : 'Climate change is location dependant.';
+            : 'Woohoo! Good Job!';
         cy.contains(`${questions.Answers[randomAnswer].text}`).click();
         if (question * 10 < 100) {
           // We're haven't finished yet so we'll check the progress bar
@@ -58,8 +58,6 @@ describe('Questionnaire loads and looks correct', () => {
         question++;
       }
     });
-    cy.get('[id=zipCodeInput]').type('90210');
-    cy.get('[id=submitButton]').click();
     cy.url().should('include', '/submit');
   });
 

--- a/src/__tests__/src/GetZipCode.test.tsx
+++ b/src/__tests__/src/GetZipCode.test.tsx
@@ -11,6 +11,13 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useMutation: () => jest.fn(),
+}));
+
+
 describe('Set Location Page', () => {
   it('has the correct text', () => {
     const h1 = 'Climate change is location dependant.';

--- a/src/api/postZipcode.ts
+++ b/src/api/postZipcode.ts
@@ -8,15 +8,15 @@ interface Response {
   sessionId: string;
 }
 interface payload {
-  zipcode: string | null;
+  postCode: string | null;
   sessionId: string | null;
 }
 
 export async function postZipcode(data: payload): Promise<Response> {
-  const { zipcode, sessionId } = data;
+  const { postCode, sessionId } = data;
   // Request body for Submission
   const REQUEST_BODY = {
-    postCode: zipcode,
+    postCode: postCode,
     sessionId: sessionId,
   };
 

--- a/src/api/postZipcode.ts
+++ b/src/api/postZipcode.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { buildUrl } from './apiHelper';
 
-// { "message": "Successfully added post code", "postCode": "90222", "sessionId": "c19d501a-4571-4338-91f3-5af55eedf7f1" }
 interface Response {
   message: string;
   postCode: string;

--- a/src/api/postZipcode.ts
+++ b/src/api/postZipcode.ts
@@ -8,7 +8,7 @@ interface Response {
   sessionId: string;
 }
 interface payload {
-  zipcode: string;
+  zipcode: string | null;
   sessionId: string | null;
 }
 
@@ -16,7 +16,7 @@ export async function postZipcode(data: payload): Promise<Response> {
   const { zipcode, sessionId } = data;
   // Request body for Submission
   const REQUEST_BODY = {
-    zipcode: zipcode,
+    postCode: zipcode,
     sessionId: sessionId,
   };
 

--- a/src/api/postZipcode.ts
+++ b/src/api/postZipcode.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { buildUrl } from './apiHelper';
+
+// { "message": "Successfully added post code", "postCode": "90222", "sessionId": "c19d501a-4571-4338-91f3-5af55eedf7f1" }
+interface Response {
+  message: string;
+  postCode: string;
+  sessionId: string;
+}
+interface payload {
+  zipcode: string;
+  sessionId: string | null;
+}
+
+export async function postZipcode(data: payload): Promise<Response> {
+  const { zipcode, sessionId } = data;
+  // Request body for Submission
+  const REQUEST_BODY = {
+    zipcode: zipcode,
+    sessionId: sessionId,
+  };
+
+  // Build the correct url
+  const ZIPCODE_ENDPOINT = '/post-code';
+  const REQUEST_URL = buildUrl(ZIPCODE_ENDPOINT);
+
+  // Try and make the request
+  try {
+    const response = await axios.post(REQUEST_URL, REQUEST_BODY);
+    const data = response.data;
+    return data;
+  } catch (err) {
+    throw err;
+  }
+}

--- a/src/hooks/useQuiz.tsx
+++ b/src/hooks/useQuiz.tsx
@@ -29,7 +29,8 @@ export const useQuiz = () => {
 
   if (progress === 10) {
     // Exit quiz after 10 questions
-    push('set-location');
+    // push('set-location');
+    push('submit');
   }
 
   const changeQuestionForward = useCallback(() => {

--- a/src/pages/GetZipCode.tsx
+++ b/src/pages/GetZipCode.tsx
@@ -11,7 +11,6 @@ import TextField from '../components/TextInput';
 import { useSession } from '../hooks/useSession';
 import Button from '../components/Button';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
-import useSessionRedirect from '../hooks/useSessionRedirect';
 import { useMutation } from 'react-query';
 import { postZipcode } from '../api/postZipcode';
 
@@ -45,17 +44,13 @@ const useStyles = makeStyles(() =>
 const GetZipCode: React.FC<{}> = () => {
   const classes = useStyles();
   const { push } = useHistory();
-  const [zipCodeState, setZipCodeState] = useState('');
   const [isInputError, setIsInputError] = useState(false);
   const [canSubmit, setCanSubmit] = useState(false);
   const { setZipCode, sessionId } = useSession();
   const [postCode, setPostCode] = useState('');
-  // const sessionId = "fb430b26-6e8e-4fca-9e6b-7cb329f48234";
-  // useSessionRedirect();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
-    setZipCodeState(value);
     setPostCode(value);
     //Input validation
     const isError = containsInvalidZipChars(value);
@@ -63,25 +58,17 @@ const GetZipCode: React.FC<{}> = () => {
   };
 
   const handleSkip = () => {
-    // push(ROUTES.ROUTE_SUBMIT);
     push(ROUTES.ROUTE_FEED);
   };
 
-  // const [mutateAddZip] = useMutation(postZipcode);
   const mutateAddZip = useMutation(
     (data: { postCode: string | null; sessionId: string | null }) => 
       postZipcode({ postCode, sessionId })
-  ); //postZipcode({ zipcode, sessionId })
+  ); 
 
   const handleSubmit = () => {
-    // setPostCode(zipCodeState);
-    // here we could set zip code (setZipCode) from useSession for session
-    // add post zip and sessionId
-    console.log('about to submit zip..', {'postcode': postCode, 'sessionId': sessionId})
-    
-    //const mutation = useMutation(body => axios.post('postZipcode', body))
+    setZipCode(postCode);  // store zipcode in context, for future use?
     mutateAddZip.mutate({postCode, sessionId});
-    // push(ROUTES.ROUTE_SUBMIT);
     push(ROUTES.ROUTE_FEED);
 
   };

--- a/src/pages/GetZipCode.tsx
+++ b/src/pages/GetZipCode.tsx
@@ -9,11 +9,11 @@ import { COLORS } from '../common/styles/CMTheme';
 import { containsInvalidZipChars, isValidZipCode } from '../helpers/zipCodes';
 import TextField from '../components/TextInput';
 import { useSession } from '../hooks/useSession';
+import { useNoSessionRedirect } from '../hooks/useNoSessionRedirect';
 import Button from '../components/Button';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 import { useMutation } from 'react-query';
 import { postZipcode } from '../api/postZipcode';
-
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -48,6 +48,7 @@ const GetZipCode: React.FC<{}> = () => {
   const [canSubmit, setCanSubmit] = useState(false);
   const { setZipCode, sessionId } = useSession();
   const [postCode, setPostCode] = useState('');
+  useNoSessionRedirect();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;

--- a/src/pages/GetZipCode.tsx
+++ b/src/pages/GetZipCode.tsx
@@ -49,14 +49,14 @@ const GetZipCode: React.FC<{}> = () => {
   const [isInputError, setIsInputError] = useState(false);
   const [canSubmit, setCanSubmit] = useState(false);
   const { setZipCode, sessionId } = useSession();
-  const [zipcode, setZipcode] = useState('');
+  const [postCode, setPostCode] = useState('');
   // const sessionId = "fb430b26-6e8e-4fca-9e6b-7cb329f48234";
   // useSessionRedirect();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setZipCodeState(value);
-    setZipcode(value);
+    setPostCode(value);
     //Input validation
     const isError = containsInvalidZipChars(value);
     setIsInputError(isError);
@@ -69,20 +69,18 @@ const GetZipCode: React.FC<{}> = () => {
 
   // const [mutateAddZip] = useMutation(postZipcode);
   const mutateAddZip = useMutation(
-    (data: { zipcode: string | null; sessionId: string | null }) => 
-      postZipcode({ zipcode, sessionId })
+    (data: { postCode: string | null; sessionId: string | null }) => 
+      postZipcode({ postCode, sessionId })
   ); //postZipcode({ zipcode, sessionId })
 
   const handleSubmit = () => {
-    setZipCode(zipCodeState);
+    // setPostCode(zipCodeState);
+    // here we could set zip code (setZipCode) from useSession for session
     // add post zip and sessionId
-    console.log('about to submit zip..', {'zipcode': zipcode, 'sessionId': sessionId})
-    const body = {
-      "postCode": "90222", 
-      "sessionId": "c19d501a-4571-4338-91f3-5af55eedf7f1"
-    };
+    console.log('about to submit zip..', {'postcode': postCode, 'sessionId': sessionId})
+    
     //const mutation = useMutation(body => axios.post('postZipcode', body))
-    mutateAddZip.mutate({zipcode, sessionId});
+    mutateAddZip.mutate({postCode, sessionId});
     // push(ROUTES.ROUTE_SUBMIT);
     push(ROUTES.ROUTE_FEED);
 
@@ -90,9 +88,9 @@ const GetZipCode: React.FC<{}> = () => {
 
   // Enable submit when zip code valid
   useEffect(() => {
-    const isValidZip = isValidZipCode(zipCodeState);
+    const isValidZip = isValidZipCode(postCode);
     setCanSubmit(isValidZip);
-  }, [zipCodeState]);
+  }, [postCode]);
 
   return (
     <PageWrapper bgColor={COLORS.ACCENT1}>
@@ -134,7 +132,7 @@ const GetZipCode: React.FC<{}> = () => {
             fullWidth={true}
             variant="filled"
             color="secondary"
-            value={zipCodeState}
+            value={postCode}
             margin="none"
             onChange={handleInputChange}
             error={isInputError}

--- a/src/pages/GetZipCode.tsx
+++ b/src/pages/GetZipCode.tsx
@@ -12,6 +12,9 @@ import { useSession } from '../hooks/useSession';
 import Button from '../components/Button';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 import useSessionRedirect from '../hooks/useSessionRedirect';
+import { useMutation } from 'react-query';
+import { postZipcode } from '../api/postZipcode';
+
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -45,25 +48,44 @@ const GetZipCode: React.FC<{}> = () => {
   const [zipCodeState, setZipCodeState] = useState('');
   const [isInputError, setIsInputError] = useState(false);
   const [canSubmit, setCanSubmit] = useState(false);
-  const { setZipCode } = useSession();
-
-  useSessionRedirect();
+  const { setZipCode, sessionId } = useSession();
+  const [zipcode, setZipcode] = useState('');
+  // const sessionId = "fb430b26-6e8e-4fca-9e6b-7cb329f48234";
+  // useSessionRedirect();
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     setZipCodeState(value);
+    setZipcode(value);
     //Input validation
     const isError = containsInvalidZipChars(value);
     setIsInputError(isError);
   };
 
   const handleSkip = () => {
-    push(ROUTES.ROUTE_SUBMIT);
+    // push(ROUTES.ROUTE_SUBMIT);
+    push(ROUTES.ROUTE_FEED);
   };
+
+  // const [mutateAddZip] = useMutation(postZipcode);
+  const mutateAddZip = useMutation(
+    (data: { zipcode: string | null; sessionId: string | null }) => 
+      postZipcode({ zipcode, sessionId })
+  ); //postZipcode({ zipcode, sessionId })
 
   const handleSubmit = () => {
     setZipCode(zipCodeState);
-    push(ROUTES.ROUTE_SUBMIT);
+    // add post zip and sessionId
+    console.log('about to submit zip..', {'zipcode': zipcode, 'sessionId': sessionId})
+    const body = {
+      "postCode": "90222", 
+      "sessionId": "c19d501a-4571-4338-91f3-5af55eedf7f1"
+    };
+    //const mutation = useMutation(body => axios.post('postZipcode', body))
+    mutateAddZip.mutate({zipcode, sessionId});
+    // push(ROUTES.ROUTE_SUBMIT);
+    push(ROUTES.ROUTE_FEED);
+
   };
 
   // Enable submit when zip code valid

--- a/src/pages/PersonalValuesFeed.tsx
+++ b/src/pages/PersonalValuesFeed.tsx
@@ -192,12 +192,19 @@ const PersonalValues: React.FC = () => {
 
           <Grid item container justify="center">
             <Box mt={4} mb={8}>
-              <Button
+              {/* <Button
                 variant="contained"
                 color="primary"
                 fullWidth
                 disableElevation
                 onClick={() => push(ROUTES.ROUTE_FEED)}
+              > */}
+              <Button
+                variant="contained"
+                color="primary"
+                fullWidth
+                disableElevation
+                onClick={() => push(ROUTES.ROUTE_LOCATION)}
               >
                 Yes, I’m ready!
               </Button>


### PR DESCRIPTION
- the user can now submit the zip cod after reading Personal values
- the zip submit page has moved. The page flow is now:

![image](https://user-images.githubusercontent.com/10048951/107019947-92314f00-67a2-11eb-868c-5fa496e4e981.png)

to:

![image](https://user-images.githubusercontent.com/10048951/107020111-bee56680-67a2-11eb-88fa-5a149d65f2b8.png)


to:

![image](https://user-images.githubusercontent.com/10048951/107020190-da507180-67a2-11eb-9472-3fcba2fe88b1.png)

to:

![image](https://user-images.githubusercontent.com/10048951/107020273-f48a4f80-67a2-11eb-8c52-2a1c6ce3aaf7.png)

to:

![image](https://user-images.githubusercontent.com/10048951/107020453-2a2f3880-67a3-11eb-81ef-0c4da1716d5f.png)
