### PR TITLE
CM-11_fix_a11y_issues

### DIFF
--- a/cypress/integration/actionsfeed.spec.ts
+++ b/cypress/integration/actionsfeed.spec.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { terminalLog } from '../support/helpers';
+
 describe('Actions feed loads and looks correct', () => {
   beforeEach(() => {
     // Set session id and accept cookies as if a returning user
@@ -39,6 +41,7 @@ describe('Actions feed loads and looks correct', () => {
   });
 
   it('The Actions feed loads and has the correct number of cards', () => {
+    cy.checkAccessibility(terminalLog);
     cy.contains('Ready to take action?').should('be.visible');
     cy.get('[data-testid="CMCard"]').should('have.length', 49);
   });

--- a/cypress/integration/climatefeed.spec.ts
+++ b/cypress/integration/climatefeed.spec.ts
@@ -50,6 +50,7 @@ describe('Climate Feed loads and looks correct', () => {
     cy.contains('Get Started').click();
     cy.contains('Your Personal Climate Feed').click();
     cy.get('[data-testid="CMCard"]').should('have.length', 21);
+    cy.checkAccessibility(terminalLog);
   });
 
   it('Card contains the correct information', () => {

--- a/cypress/integration/menubar.spec.ts
+++ b/cypress/integration/menubar.spec.ts
@@ -3,11 +3,12 @@
 import { terminalLog } from '../support/helpers.ts';
 
 describe('Menu bar opens and looks correct', () => {
-  it('can open menubar', () => {
+  it.only('can open menubar', () => {
     cy.acceptCookies();
     cy.visit('/start');
     cy.get('[aria-label="menu"]').should('be.visible').click();
     cy.contains('About ClimateMind').should('be.visible');
+    cy.checkAccessibility(terminalLog);
     cy.percySnapshot('MenuBar');
   });
 });

--- a/cypress/integration/mythsfeed.spec.ts
+++ b/cypress/integration/mythsfeed.spec.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { terminalLog } from '../support/helpers';
+
 describe('Myth Feed loads and looks correct', () => {
   beforeEach(() => {
     // Set session id and accept cookies as if a returning user
@@ -44,6 +46,7 @@ describe('Myth Feed loads and looks correct', () => {
   });
 
   it('The myth feed loads and has the correct number of cards', () => {
+    cy.checkAccessibility(terminalLog);
     cy.contains('Climate Mind is against misinformation').should('be.visible');
     cy.get('[data-testid="CMCard"]').should('have.length', 8);
   });

--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -45,6 +45,7 @@ describe('Personal values page loads and looks correct', () => {
 
   it('can complete questionnaire and see personal values', () => {
     // Check personality cards
+    cy.checkAccessibility(terminalLog);
     cy.contains('Security').should('be.visible');
     cy.get('[data-testid="CMCardMore"]').each((moreButton) => {
       cy.get(moreButton).should('have.text', 'MORE');

--- a/src/__tests__/src/ClimateFeed.test.tsx
+++ b/src/__tests__/src/ClimateFeed.test.tsx
@@ -68,7 +68,10 @@ const dummyData = {
         },
       ],
       effectTitle: 'increase in flooding of land and property',
-      effectSpecificMythIRIs: ['RCqODufKJse3xkgAny5v5fI', 'RXlELjsOUaVbJqmvO91WFL'],
+      effectSpecificMythIRIs: [
+        'RCqODufKJse3xkgAny5v5fI',
+        'RXlELjsOUaVbJqmvO91WFL',
+      ],
       imageUrl:
         'https://api.creativecommons.engineering/v1/thumbs/1dc085e5-a90e-4f3e-ae79-17d8e209516c',
     },
@@ -116,7 +119,10 @@ const dummyData = {
         },
       ],
       effectTitle: 'increase in suicide',
-      effectSpecificMythIRIs: ['RCqODufKJse3xkgAny5v5fI', 'RXlELjsOUaVbJqmvO91WFL'],
+      effectSpecificMythIRIs: [
+        'RCqODufKJse3xkgAny5v5fI',
+        'RXlELjsOUaVbJqmvO91WFL',
+      ],
       imageUrl:
         'https://im.indiatimes.in/media/content/2016/Jun/netsafe%20org_1466062085.jpg',
     },
@@ -167,7 +173,10 @@ const dummyData = {
         },
       ],
       effectTitle: 'increase in physical violence',
-      effectSpecificMythIRIs: ['RCqODufKJse3xkgAny5v5fI', 'RXlELjsOUaVbJqmvO91WFL'],
+      effectSpecificMythIRIs: [
+        'RCqODufKJse3xkgAny5v5fI',
+        'RXlELjsOUaVbJqmvO91WFL',
+      ],
       imageUrl:
         'https://i0.pickpik.com/photos/744/359/676/fist-strength-anger-tear-preview.jpg',
     },
@@ -215,7 +224,10 @@ const dummyData = {
         },
       ],
       effectTitle: 'increase in asthma complications',
-      effectSpecificMythIRIs: ['RCqODufKJse3xkgAny5v5fI', 'RXlELjsOUaVbJqmvO91WFL'],
+      effectSpecificMythIRIs: [
+        'RCqODufKJse3xkgAny5v5fI',
+        'RXlELjsOUaVbJqmvO91WFL',
+      ],
       imageUrl:
         'https://live.staticflickr.com/3382/3630262585_f9e666b8bb_b.jpg',
     },
@@ -264,40 +276,46 @@ const dummyData = {
         },
       ],
       effectTitle: 'increase in heat stroke',
-      effectSpecificMythIRIs: ['RCqODufKJse3xkgAny5v5fI', 'RXlELjsOUaVbJqmvO91WFL'],
+      effectSpecificMythIRIs: [
+        'RCqODufKJse3xkgAny5v5fI',
+        'RXlELjsOUaVbJqmvO91WFL',
+      ],
       imageUrl:
         'https://www.stripes.com/polopoly_fs/1.578924.1556551744!/image/image.jpg_gen/derivatives/landscape_900/image.jpg',
     },
   ],
 };
 
-const dummyMyths = [{
-  faultyLogicDescription:
-    'Jumping to conclusions\nPast climate change actually sends the opposite message than what the myth concludes.',
-  iri: 'R8ZhofBtOtoHDSFtEhoLGir',
-  mythClaim:
-    "Climate's changed before\n\nClimate is always changing.thousand years, and there have been previous periods that appear to have been warmer than the present despite CO2 levels being lower than they are now. More recently, we have had the medieval warm period and the little ice age. (from Richard Lindzen)",
-  mythRebuttal:
-    'Greenhouse gasses, principally CO2, have controlled most ancient climate changes. This time around humans are the cause, mainly by our CO2 emissions.',
-  mythSources: [
-    'https://skepticalscience.com/climate-change-little-ice-age-medieval-warm-period.htm',
-  ],
-  mythTitle: 'Climate has changed before',
-  mythVideos: ['https://youtu.be/H5kejSYPD7U'],
-},{
-  faultyLogicDescription:
-    'Jumping to conclusions\nPast climate change actually sends the opposite message than what the myth concludes.',
-  iri: 'R8ZhofBtOtoHDSFtEhoLGir',
-  mythClaim:
-    "Climate's changed before\n\nClimate is always changing. We have had ice ages and warmer periods when alligators were found in Spitzbergen. Ice ages have occurred in a hundred thousand year cycle for the last 700 thousand years, and there have been previous periods that appear to have been warmer than the present despite CO2 levels being lower than they are now. More recently, we have had the medieval warm period and the little ice age. (from Richard Lindzen)",
-  mythRebuttal:
-    'Greenhouse gasses, principally CO2, have controlled most ancient climate changes. This time around humans are the cause, mainly by our CO2 emissions.',
-  mythSources: [
-    'https://skepticalscience.com/climate-change-little-ice-age-medieval-warm-period.htm',
-  ],
-  mythTitle: 'Climate has changed before',
-  mythVideos: ['https://youtu.be/H5kejSYPD7U'],
-}]
+const dummyMyths = [
+  {
+    faultyLogicDescription:
+      'Jumping to conclusions\nPast climate change actually sends the opposite message than what the myth concludes.',
+    iri: 'R8ZhofBtOtoHDSFtEhoLGir',
+    mythClaim:
+      "Climate's changed before\n\nClimate is always changing.thousand years, and there have been previous periods that appear to have been warmer than the present despite CO2 levels being lower than they are now. More recently, we have had the medieval warm period and the little ice age. (from Richard Lindzen)",
+    mythRebuttal:
+      'Greenhouse gasses, principally CO2, have controlled most ancient climate changes. This time around humans are the cause, mainly by our CO2 emissions.',
+    mythSources: [
+      'https://skepticalscience.com/climate-change-little-ice-age-medieval-warm-period.htm',
+    ],
+    mythTitle: 'Climate has changed before',
+    mythVideos: ['https://youtu.be/H5kejSYPD7U'],
+  },
+  {
+    faultyLogicDescription:
+      'Jumping to conclusions\nPast climate change actually sends the opposite message than what the myth concludes.',
+    iri: 'R8ZhofBtOtoHDSFtEhoLGir',
+    mythClaim:
+      "Climate's changed before\n\nClimate is always changing. We have had ice ages and warmer periods when alligators were found in Spitzbergen. Ice ages have occurred in a hundred thousand year cycle for the last 700 thousand years, and there have been previous periods that appear to have been warmer than the present despite CO2 levels being lower than they are now. More recently, we have had the medieval warm period and the little ice age. (from Richard Lindzen)",
+    mythRebuttal:
+      'Greenhouse gasses, principally CO2, have controlled most ancient climate changes. This time around humans are the cause, mainly by our CO2 emissions.',
+    mythSources: [
+      'https://skepticalscience.com/climate-change-little-ice-age-medieval-warm-period.htm',
+    ],
+    mythTitle: 'Climate has changed before',
+    mythVideos: ['https://youtu.be/H5kejSYPD7U'],
+  },
+];
 
 const titles = dummyData.climateEffects.map((effect) => effect.effectTitle);
 

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -45,7 +45,13 @@ const CmAppBar: React.FC = () => {
     <>
       <div className={classes.root}>
         <Slide in={!trigger}>
-          <AppBar position="fixed" color="default" data-testid="AppBar">
+          <AppBar
+            position="fixed"
+            color="default"
+            data-testid="AppBar"
+            id="AppBar"
+            aria-label="Climate Mind"
+          >
             <Toolbar variant="dense" disableGutters={true}>
               <Typography variant="h6" className={classes.title}>
                 Climate Mind
@@ -53,6 +59,7 @@ const CmAppBar: React.FC = () => {
 
               <IconButton
                 edge="start"
+                id="TopMenuToggle"
                 color="inherit"
                 aria-label="menu"
                 aria-expanded={isMenuShowing}

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -85,16 +85,22 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
       <Slide direction="down" in={isShowing}>
         <Dialog
           fullScreen
+          aria-labelledby="MenuSpacer"
           open={isShowing}
           onClose={handleClose}
           className={classes.menuPaper}
           keepMounted
           style={{ zIndex: 10000 }}
           data-testid="TopMenuPaper"
+          TransitionProps={{ role: 'presentation' } as any} // This is required to for MUI to give the dialog only one role, removing cause the cypress accessability check to fail.
         >
           <DialogContent>
             {/* Offset for app bar */}
-            <div className={classes.offset} />
+            <div
+              id="MenuSpacer"
+              className={classes.offset}
+              aria-label="Climate Mind Top Menu"
+            />
 
             <Grid item>
               <List>
@@ -102,14 +108,14 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                 {sessionId && (
                   <>
                     <ListItem
-                      button
+                      component="li"
                       disableGutters={true}
                       onClick={() => handleNav(ROUTES.ROUTE_VALUES)}
                     >
                       <ListItemText primary="Personal Values" />
                     </ListItem>
                     <ListItem
-                      button
+                      component="li"
                       disableGutters={true}
                       onClick={handleRetakeQuiz}
                     >
@@ -121,7 +127,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                 {/* Menu List Items  */}
                 {menuLinks.map((item, index) => (
                   <ListItem
-                    button
+                    component="li"
                     key={index}
                     disableGutters={true}
                     onClick={() => handleNavAway(item.url)}
@@ -131,7 +137,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
                 ))}
                 {/* Privacy Policy */}
                 <ListItem
-                  button
+                  component="li"
                   disableGutters={true}
                   onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
                 >

--- a/src/components/AppBar/Socials.tsx
+++ b/src/components/AppBar/Socials.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
-import List from '@material-ui/core/List';
+import { List, ListItem } from '@material-ui/core';
 
 import { ReactComponent as FacebookIcon } from '../../assets/socials/Facebook.svg';
 import { ReactComponent as TwitterIcon } from '../../assets/socials/Twitter.svg';
@@ -22,6 +22,11 @@ const useStyles = makeStyles(() =>
       height: '44px',
       width: '44px',
       color: '#39f5ad',
+    },
+    li: {
+      display: 'inline',
+      margin: 0,
+      padding: 0,
     },
   })
 );
@@ -72,13 +77,15 @@ const Socials: React.FC = () => {
       <List>
         {socialLinks.map((social, index) => {
           return (
-            <IconButton
-              aria-label={social.name}
-              key={index}
-              onClick={() => handleOpen(social.url)}
-            >
-              {social.icon}
-            </IconButton>
+            <ListItem component="li" className={classes.li}>
+              <IconButton
+                aria-label={social.name}
+                key={index}
+                onClick={() => handleOpen(social.url)}
+              >
+                {social.icon}
+              </IconButton>
+            </ListItem>
           );
         })}
       </List>


### PR DESCRIPTION
The ticket here was to fix a text contrast issue which mean a11y checks had been disables in the quiz (i think). This had alreay been fix but in the course of investigating I noticed that check were missing on some pages. 

- Added a11y check to any pages where this was not being checked
- Had to make some changes to the top menu to pass accesability. 

Note:  [I encountered this issue with mui](https://github.com/mui-org/material-ui/issues/18935) which i had to resolve by passing TransitionProps. 