### PR TITLE
CM-422_width_fix_bottom_menu

### DIFF
--- a/src/components/AppBar/Socials.tsx
+++ b/src/components/AppBar/Socials.tsx
@@ -77,7 +77,11 @@ const Socials: React.FC = () => {
       <List>
         {socialLinks.map((social, index) => {
           return (
-            <ListItem component="li" className={classes.li}>
+            <ListItem
+              component="li"
+              className={classes.li}
+              key={`social-icon-${index}`}
+            >
               <IconButton
                 aria-label={social.name}
                 key={index}

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -74,20 +74,37 @@ const BottomMenu: React.FC<BottomMenuProps> = ({
     })
   );
 
+  const iconStyle = { height: '20px' };
+
   //supported icons
   const getIcon = (type: string) => {
     switch (type) {
       case '/climate-feed':
-        return <HomeIcon data-testid="BottomMenuIconsFeed" />;
+        return <HomeIcon style={iconStyle} data-testid="BottomMenuIconsFeed" />;
       case '/myths':
-        return <AnnouncementIcon data-testid="BottomMenuIconsMyths" />;
+        return (
+          <AnnouncementIcon
+            style={iconStyle}
+            data-testid="BottomMenuIconsMyths"
+          />
+        );
       case '/solutions':
-        return <EmojiObjectsIcon data-testid="BottomMenuIconsSolutions" />;
+        return (
+          <EmojiObjectsIcon
+            style={iconStyle}
+            data-testid="BottomMenuIconsSolutions"
+          />
+        );
       case '/saved':
-        return <BookmarksIcon data-testid="BottomMenuIconsSaved" />;
+        return (
+          <BookmarksIcon style={iconStyle} data-testid="BottomMenuIconsSaved" />
+        );
       case '/conversations':
         return (
-          <QuestionAnswerIcon data-testid="BottomMenuIconsConversations" />
+          <QuestionAnswerIcon
+            style={iconStyle}
+            data-testid="BottomMenuIconsConversations"
+          />
         );
       default:
         return null;

--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -80,7 +80,7 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
         padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
       },
       card: {
-        minWidth: '343px',
+        minWidth: '304px',
       },
       media: {
         margin: 0,

--- a/src/components/Wrapper.tsx
+++ b/src/components/Wrapper.tsx
@@ -16,7 +16,7 @@ const Wrapper: React.FC<WrapperProps> = ({
     root: {
       backgroundColor: bgColor ? bgColor : 'inherit',
       minHeight: fullHeight ? '100vh' : 'auto',
-      minWidth: '375px',
+      minWidth: '304px',
       width: '100%',
       margin: 0,
       padding: 0,

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Grid, makeStyles, Typography, Box } from '@material-ui/core';
-import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import { COLORS } from '../common/styles/CMTheme';
 import Loader from '../components/Loader';
 import Card from '../components/Card';

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -41,7 +41,7 @@ const ClimateFeed: React.FC = () => {
         container
         className={classes.root}
         data-testid="Myths Feed"
-        justify="space-around"
+        justify="space-between"
       >
         <Wrapper bgColor={COLORS.ACCENT5}>
           <Grid item sm={false} lg={4}>
@@ -63,25 +63,11 @@ const ClimateFeed: React.FC = () => {
               justify="space-around"
             >
               <Grid item className={classes.feedContainer}>
-                <Grid item>
-                  <Box mt={2} mb={0} mx={2}>
-                    <Grid
-                      container
-                      direction="row"
-                      alignItems="center"
-                      spacing={5}
-                    >
-                      <Grid item xs={3}>
-                        <Logo width="76" data-testid="climate-mind-logo" />
-                      </Grid>
-                      <Grid item xs={9}>
-                        <Typography variant="h4">
-                          Your Personal Climate Feed
-                        </Typography>
-                      </Grid>
-                    </Grid>
-                  </Box>
-                </Grid>
+                <Box my={3} px={1}>
+                  <Typography variant="h4">
+                    Your Personal Climate Feed
+                  </Typography>
+                </Box>
 
                 <ScrollToTopOnMount />
                 {data.climateEffects.map((effect, i) => {

--- a/src/pages/MythFeed.tsx
+++ b/src/pages/MythFeed.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useQuery } from 'react-query';
 import { getMyths } from '../api/getMyths';
-import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import { COLORS } from '../common/styles/CMTheme';
 import { Typography, Grid, makeStyles, Box } from '@material-ui/core';
 import Loader from '../components/Loader';
@@ -66,20 +65,11 @@ const MythFeed: React.FC = () => {
             justify="space-between"
             alignItems="center"
           >
-            <Grid item container direction="row" justify="space-between">
-              <Box mt={2} mb={3} mx={2}>
-                <Grid container direction="row" alignItems="center" spacing={5}>
-                  <Grid item xs={3}>
-                    <Logo width="76" data-testid="climate-mind-logo" />
-                  </Grid>
-                  <Grid item xs={9}>
-                    <Typography variant="h4">
-                      Climate Mind is against misinformation.
-                    </Typography>
-                  </Grid>
-                </Grid>
-              </Box>
-            </Grid>
+            <Box my={3} px={1}>
+              <Typography variant="h4">
+                Climate Mind is against misinformation.
+              </Typography>
+            </Box>
 
             <Grid item sm={12} lg={12} container>
               {myths.map((myth, i) => (

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useQuery } from 'react-query';
 import { getSolutions } from '../api/getSolutions';
-import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import { COLORS } from '../common/styles/CMTheme';
 import { Typography, Grid, makeStyles, Box } from '@material-ui/core';
 import Loader from '../components/Loader';

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -80,26 +80,9 @@ const SolutionsFeed: React.FC = () => {
             justify="center"
             alignItems="center"
           >
-            <Grid
-              item
-              xs={12}
-              container
-              direction="column"
-              justify="space-around"
-              alignItems="stretch"
-              data-testid="top-box"
-            >
-              <Box mt={2} mb={3} mx={2} data-testid="next-box">
-                <Grid container direction="row" alignItems="center" spacing={1}>
-                  <Grid item xs={3}>
-                    <Logo width="76" data-testid="climate-mind-logo" />
-                  </Grid>
-                  <Grid item xs={9}>
-                    <Typography variant="h4">Ready to take action?</Typography>
-                  </Grid>
-                </Grid>
-              </Box>
-            </Grid>
+            <Box my={3} px={1} data-testid="next-box">
+              <Typography variant="h4">Ready to take action?</Typography>
+            </Box>
 
             <Grid item sm={12} lg={12} className={classes.feedContainer}>
               {React.Children.toArray(


### PR DESCRIPTION
This PR addresses the following 3 issues: 

CM-422 - Scale/position of bottom-menu changes between pages (iphone 5s)

CM-424 - Remove Logo icon from page headers

CM-421 - Action icon in bottom-menu aren’t the right size - path should be 20px high

Screenshots attached from an iphone 5s. Initially picked up cm-422, issue was a min width was set which was greater than the 5s screen width. Reduced with to allow screens down to 320px and tested through the app. This fixed a number of other issues in the smaller screen size so resolved them too. 

**Out of scope**

The bottom menu still creeps over the allowed space by a couple of px. Unless we change conversations on the menu to something shorter there is no way round that for now. 

## Before (iphone 5s)

<img width="359" alt="Screenshot 2021-02-15 at 21 38 20" src="https://user-images.githubusercontent.com/44759513/107996489-6dc24780-6fd8-11eb-9bd0-dd43db502481.png">
<img width="363" alt="Screenshot 2021-02-15 at 21 38 30" src="https://user-images.githubusercontent.com/44759513/107996499-7155ce80-6fd8-11eb-8711-22f1f1ef6192.png">
<img width="365" alt="Screenshot 2021-02-15 at 21 38 39" src="https://user-images.githubusercontent.com/44759513/107996506-74e95580-6fd8-11eb-9737-438a4cca7e83.png">

## After 

<img width="367" alt="Screenshot 2021-02-15 at 21 37 25" src="https://user-images.githubusercontent.com/44759513/107996521-7fa3ea80-6fd8-11eb-817d-40b65c099e90.png">
<img width="358" alt="Screenshot 2021-02-15 at 21 37 39" src="https://user-images.githubusercontent.com/44759513/107996525-829edb00-6fd8-11eb-9741-c45d99f78a21.png">
<img width="350" alt="Screenshot 2021-02-15 at 21 38 03" src="https://user-images.githubusercontent.com/44759513/107996534-86326200-6fd8-11eb-802b-75ea561a372a.png">



