### PR TITLE
Cm 363 card header in climate personality displays incorrectly on widescreen

### DIFF
--- a/src/components/CardHeader.tsx
+++ b/src/components/CardHeader.tsx
@@ -103,41 +103,41 @@ const CardHeader: React.FC<CardHeaderProps> = ({
             <CardIcon actionType={cardIcon} />
           </Grid>
         )}
-            <Box p={1} style={{ border: "1px solid black"}}>
-        <Grid item xs={12} container>
-          {preTitle && (
-            <Grid item xs={10} container alignItems="center">
-              {isPossiblyLocal === 1 && (
-                <Grid
-                  item
-                  xs={1}
-                  className={classes.preTitleIcon}
-                  data-testid="LocalIcon"
-                >
-                  <RoomIcon style={preIconStyles} />
+        <Box p={1}>
+          <Grid item xs={12} container>
+            {preTitle && (
+              <Grid item xs={10} container alignItems="center">
+                {isPossiblyLocal === 1 && (
+                  <Grid
+                    item
+                    xs={1}
+                    className={classes.preTitleIcon}
+                    data-testid="LocalIcon"
+                  >
+                    <RoomIcon style={preIconStyles} />
+                  </Grid>
+                )}
+                <Grid item xs={9} data-testid="PreTitle">
+                  <Typography
+                    className={classes.preTitle}
+                    gutterBottom
+                    variant="h3"
+                    component="h3"
+                  >
+                    {preTitle}
+                  </Typography>
                 </Grid>
-              )}
-              <Grid item xs={9} data-testid="PreTitle">
-                <Typography
-                  className={classes.preTitle}
-                  gutterBottom
-                  variant="h3"
-                  component="h3"
-                >
-                  {preTitle}
-                </Typography>
               </Grid>
-            </Grid>
-          )}
-          <Typography
-            className={classes.title}
-            gutterBottom
-            variant="h6"
-            component="h2"
-          >
-            {title}
-          </Typography>
-        </Grid>
+            )}
+            <Typography
+              className={classes.title}
+              gutterBottom
+              variant="h6"
+              component="h2"
+            >
+              {title}
+            </Typography>
+          </Grid>
         </Box>
       </Grid>
     </div>

--- a/src/components/CardHeader.tsx
+++ b/src/components/CardHeader.tsx
@@ -1,4 +1,4 @@
-import { Typography, Grid, Theme } from '@material-ui/core';
+import { Typography, Grid, Theme, Box } from '@material-ui/core';
 import CardIcon from './CardIcon';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import { COLORS } from '../common/styles/CMTheme';
@@ -95,15 +95,16 @@ const CardHeader: React.FC<CardHeaderProps> = ({
       >
         {cardIcon && (
           <Grid
-            item
-            xs={2}
-            className={classes.iconContainer}
-            data-testid="CardIcon"
+          item
+          xs={2}
+          className={classes.iconContainer}
+          data-testid="CardIcon"
           >
             <CardIcon actionType={cardIcon} />
           </Grid>
         )}
-        <Grid item xs={10} container>
+            <Box p={1} style={{ border: "1px solid black"}}>
+        <Grid item xs={12} container>
           {preTitle && (
             <Grid item xs={10} container alignItems="center">
               {isPossiblyLocal === 1 && (
@@ -137,6 +138,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({
             {title}
           </Typography>
         </Grid>
+        </Box>
       </Grid>
     </div>
   );

--- a/src/stories/components/CardHeadline.stories.tsx
+++ b/src/stories/components/CardHeadline.stories.tsx
@@ -51,7 +51,7 @@ WithIsLocal.args = {
 export const NumberCards = Template.bind({});
 NumberCards.args = {
   ...Default.args,
-  cardIcon: 'idea',
+  preTitle: 'No. 3'
 };
 
 export const BackgroundColor = Template.bind({});


### PR DESCRIPTION
Fixed the alignment of card header content, see image:

![image](https://user-images.githubusercontent.com/10048951/108602136-b5fab480-73a0-11eb-8145-db28667b2772.png)
