### PR TITLE
CM-426_Sources/Details tab unselected correct color

### DIFF
--- a/src/components/CardHeader.tsx
+++ b/src/components/CardHeader.tsx
@@ -48,12 +48,6 @@ const CardHeader: React.FC<CardHeaderProps> = ({
         width: '100%',
         padding: theme.spacing(2),
       },
-      iconContainer: {
-        textAlign: 'center',
-      },
-      icon: {
-        textAlign: 'center',
-      },
       cardNumber: {
         textTransform: 'uppercase',
         letterSpacing: '0.5pt',
@@ -93,51 +87,52 @@ const CardHeader: React.FC<CardHeaderProps> = ({
         spacing={2}
         className={classes.cardHeader}
       >
-        {cardIcon && (
-          <Grid
-          item
-          xs={2}
-          className={classes.iconContainer}
-          data-testid="CardIcon"
-          >
-            <CardIcon actionType={cardIcon} />
-          </Grid>
-        )}
-        <Box p={1}>
-          <Grid item xs={12} container>
-            {preTitle && (
-              <Grid item xs={10} container alignItems="center">
-                {isPossiblyLocal === 1 && (
-                  <Grid
-                    item
-                    xs={1}
-                    className={classes.preTitleIcon}
-                    data-testid="LocalIcon"
-                  >
-                    <RoomIcon style={preIconStyles} />
-                  </Grid>
-                )}
-                <Grid item xs={9} data-testid="PreTitle">
-                  <Typography
-                    className={classes.preTitle}
-                    gutterBottom
-                    variant="h3"
-                    component="h3"
-                  >
-                    {preTitle}
-                  </Typography>
-                </Grid>
-              </Grid>
-            )}
-            <Typography
-              className={classes.title}
-              gutterBottom
-              variant="h6"
-              component="h2"
+        <Box display="flex" flexDirection="row" alignItems="center">
+          {cardIcon && (
+            <Grid
+              item
+              xs={2}
+              data-testid="CardIcon"
             >
-              {title}
-            </Typography>
-          </Grid>
+              <CardIcon actionType={cardIcon} />
+            </Grid>
+          )}
+          <Box p={1}>
+            <Grid item xs={12} container>
+              {preTitle && (
+                <Grid item xs={10} container alignItems="center">
+                  {isPossiblyLocal === 1 && (
+                    <Grid
+                      item
+                      xs={1}
+                      className={classes.preTitleIcon}
+                      data-testid="LocalIcon"
+                    >
+                      <RoomIcon style={preIconStyles} />
+                    </Grid>
+                  )}
+                  <Grid item xs={9} data-testid="PreTitle">
+                    <Typography
+                      className={classes.preTitle}
+                      gutterBottom
+                      variant="h3"
+                      component="h3"
+                    >
+                      {preTitle}
+                    </Typography>
+                  </Grid>
+                </Grid>
+              )}
+              <Typography
+                className={classes.title}
+                gutterBottom
+                variant="h6"
+                component="h2"
+              >
+                {title}
+              </Typography>
+            </Grid>
+          </Box>
         </Box>
       </Grid>
     </div>

--- a/src/components/TabbedContent.tsx
+++ b/src/components/TabbedContent.tsx
@@ -5,6 +5,7 @@ import { TAction } from '../types/Actions';
 import DescriptionIcon from '@material-ui/icons/Description';
 import AssignmentIcon from '@material-ui/icons/Assignment';
 import Box from '@material-ui/core/Box';
+import { COLORS } from '../common/styles/CMTheme';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -52,6 +53,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   tab: {
     textTransform: 'capitalize',
     paddingBottom: theme.spacing(2),
+    color: COLORS.ICON_LIGHT,
+    '&.Mui-selected': {
+      color: COLORS.DK_TEXT,
+    }
   },
   icon: {
     marginBottom: '0 !important',


### PR DESCRIPTION
This PR contains 2 bug fixes: CM-426 and CM-531

- CM-426 correct color on inactive Source and details, header displays correctly

before:
 
![image](https://user-images.githubusercontent.com/10048951/109420278-d4306800-79d1-11eb-98d0-1ab067f72b6d.png)

after:
![image](https://user-images.githubusercontent.com/10048951/109420295-ed391900-79d1-11eb-8540-47425e4e1bf8.png)

- CM-531 Myth header displays wrongly
after:
![image](https://user-images.githubusercontent.com/10048951/109420334-19ed3080-79d2-11eb-8943-9458c53cd965.png)
and:
![image](https://user-images.githubusercontent.com/10048951/109420370-53be3700-79d2-11eb-94c8-ace12ca8304a.png)

