### PR TITLE
Cm 528 make actions feed responsive

### DIFF
--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -14,9 +14,18 @@ describe('Personal values page loads and looks correct', () => {
       response: 'fixture:questions.json',
     });
     cy.route({
+      method: 'GET',
+      url: '/climate-feed',
+      response: 'fixture:climate-feed.json',
+    });
+    cy.route({
       method: 'POST',
       url: '/scores',
       response: `{"sessionId": "${sessionId}"}`,
+    });
+    cy.route({
+      method: 'POST',
+      url: '/post-code',
     });
     cy.route({
       method: 'GET',
@@ -63,8 +72,8 @@ describe('Personal values page loads and looks correct', () => {
     cy.get('[id=zipCodeInput]').type('90210');
     cy.get('[id=submitButton]').click();
     // Retake the quiz
-    cy.go('back');
-    cy.go('back');
+    // cy.go('back');
+    // cy.go('back');
     cy.contains('Climate Personality not quite right?').should('be.visible');
     cy.contains('Retake the Quiz').should('be.visible').click();
     cy.contains('Q1').should('be.visible');

--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -5,6 +5,7 @@ import { terminalLog } from '../support/helpers';
 describe('Personal values page loads and looks correct', () => {
   beforeEach(() => {
     cy.acceptCookies();
+    cy.setSession();
     const sessionId = '1234';
 
     cy.server();
@@ -15,7 +16,7 @@ describe('Personal values page loads and looks correct', () => {
     });
     cy.route({
       method: 'GET',
-      url: '/climate-feed',
+      url: `/feed?session-id=${sessionId}`,
       response: 'fixture:climate-feed.json',
     });
     cy.route({
@@ -26,6 +27,12 @@ describe('Personal values page loads and looks correct', () => {
     cy.route({
       method: 'POST',
       url: '/post-code',
+      response: {
+        message: 'Successfully added post code',
+        postCode: '90210',
+        sessionId: '1234',
+      },
+      status: 201,
     });
     cy.route({
       method: 'GET',
@@ -71,13 +78,9 @@ describe('Personal values page loads and looks correct', () => {
     cy.url().should('include', '/set-location');
     cy.get('[id=zipCodeInput]').type('90210');
     cy.get('[id=submitButton]').click();
-    // Retake the quiz
-    // cy.go('back');
-    // cy.go('back');
-    cy.contains('Climate Personality not quite right?').should('be.visible');
-    cy.contains('Retake the Quiz').should('be.visible').click();
-    cy.contains('Q1').should('be.visible');
+    cy.url().should('include', '/climate-feed');
   });
+
   it('retake the quiz', () => {
     cy.contains('Climate Personality not quite right?').should('be.visible');
     cy.contains('Retake the Quiz').should('be.visible').click();

--- a/src/__tests__/src/__components__/PageContent.test.tsx
+++ b/src/__tests__/src/__components__/PageContent.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import PageContent from '../../../components/PageContent';
+
+describe('Page Content', () => {
+  it('It renders children', () => {
+    const { getByText } = render(
+      <PageContent>
+        <h1>This is a title</h1>
+        <p>This is a paragraph</p>
+      </PageContent>
+    );
+    const title = getByText('This is a title');
+    const paragraph = getByText('This is a paragraph');
+    expect(title);
+    expect(paragraph);
+  });
+});

--- a/src/__tests__/src/__components__/PageTitle.test.tsx
+++ b/src/__tests__/src/__components__/PageTitle.test.tsx
@@ -4,15 +4,8 @@ import PageTitle from '../../../components/PageTitle';
 
 describe('Page Title', () => {
   it('It renders children', () => {
-    const { getByText } = render(
-      <PageTitle>
-        <h1>This is a title</h1>
-        <p>This is a paragraph</p>
-      </PageTitle>
-    );
+    const { getByText } = render(<PageTitle>This is a title</PageTitle>);
     const title = getByText('This is a title');
-    const paragraph = getByText('This is a paragraph');
     expect(title);
-    expect(paragraph);
   });
 });

--- a/src/__tests__/src/__components__/PageTitle.test.tsx
+++ b/src/__tests__/src/__components__/PageTitle.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import PageTitle from '../../../components/PageTitle';
+
+describe('Page Title', () => {
+  it('It renders children', () => {
+    const { getByText } = render(
+      <PageTitle>
+        <h1>This is a title</h1>
+        <p>This is a paragraph</p>
+      </PageTitle>
+    );
+    const title = getByText('This is a title');
+    const paragraph = getByText('This is a paragraph');
+    expect(title);
+    expect(paragraph);
+  });
+});

--- a/src/common/styles/CMTheme.ts
+++ b/src/common/styles/CMTheme.ts
@@ -39,17 +39,27 @@ export default createMuiTheme({
   },
   typography: {
     fontFamily: 'Bilo',
+    h1: {
+      fontFamily: 'atten-round-new',
+      fontSize: '80px',
+      fontWeight: 900,
+      color: TEXT_COLOR,
+    },
+    h2: {
+      fontSize: '48px',
+      fontWeight: 900,
+      color: TEXT_COLOR,
+    },
     h3: {
       fontFamily: 'atten-round-new',
-      fontSize: '32pt',
+      fontSize: '34px',
+      fontWeight: 900,
       letterSpacing: '1.6pt',
       color: TEXT_COLOR,
-      fontWeight: 500,
     },
     h4: {
-      fontFamily: 'atten-round-new',
-      fontSize: '24pt',
-      fontWeight: 800,
+      fontSize: '24px',
+      fontWeight: 900,
       letterSpacing: '1.6pt',
       color: TEXT_COLOR,
     },
@@ -60,18 +70,14 @@ export default createMuiTheme({
       letterSpacing: '1.6pt',
       color: TEXT_COLOR,
     },
-    h2: {
-      fontSize: '14pt',
-      color: TEXT_COLOR,
-    },
     h6: {
       fontSize: '16pt',
       color: TEXT_COLOR,
       lineHeight: '1.2',
     },
     subtitle1: {
-      fontSize: 16,
-      fontWeight: 800,
+      fontSize: '16px',
+      fontWeight: 900,
       letterSpacing: '0.8pt',
       lineHeight: '1.4',
       color: TEXT_COLOR,
@@ -85,7 +91,7 @@ export default createMuiTheme({
       color: TEXT_COLOR,
     },
     body1: {
-      fontSize: 16,
+      fontSize: '16px',
       fontWeight: 400,
       letterSpacing: 0,
       lineHeight: '1.4',

--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -42,10 +42,10 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
   const useStyles = makeStyles((theme: Theme) =>
     createStyles({
       root: {
-        width: '100%',
+        padding: `0 ${theme.spacing(2)}`,
       },
       paper: {
-        maxWidth: 'calc(100% - 24px) !important',
+        maxWidth: '640px',
         height: '100%',
         backgroundColor: bgColor ? bgColor : '#FFF',
         marginTop: '-16px',
@@ -122,6 +122,7 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
         maxWidth="sm"
         classes={{
           paperWidthSm: classes.paper,
+          container: classes.root,
         }}
       >
         <Slide direction="up" in={showMore} mountOnEnter unmountOnExit>

--- a/src/components/CardOverlay.tsx
+++ b/src/components/CardOverlay.tsx
@@ -42,7 +42,7 @@ const CMCardOverlay: React.FC<CMCardOverlayProps> = ({
   const useStyles = makeStyles((theme: Theme) =>
     createStyles({
       root: {
-        padding: `0 ${theme.spacing(2)}`,
+        padding: `0 8px`,
       },
       paper: {
         maxWidth: '640px',

--- a/src/components/PageContent.tsx
+++ b/src/components/PageContent.tsx
@@ -2,9 +2,11 @@ import { createStyles, makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 
 const PageContent: React.FC = ({ children }) => {
-  const useStyles = makeStyles((theme) =>
+  const useStyles = makeStyles(() =>
     createStyles({
-      root: {},
+      root: {
+        maxWidth: '640px',
+      },
     })
   );
 

--- a/src/components/PageContent.tsx
+++ b/src/components/PageContent.tsx
@@ -1,0 +1,16 @@
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import React from 'react';
+
+const PageContent: React.FC = ({ children }) => {
+  const useStyles = makeStyles((theme) =>
+    createStyles({
+      root: {},
+    })
+  );
+
+  const classes = useStyles();
+
+  return <main className={classes.root}>{children}</main>;
+};
+
+export default PageContent;

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
+
+const PageTitle: React.FC = ({ children }) => {
+  const useStyles = makeStyles((theme) =>
+    createStyles({
+      root: {
+        textAlign: 'center',
+      },
+    })
+  );
+
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <Typography variant="h1">{children};</Typography>
+    </div>
+  );
+};
+
+export default PageTitle;

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -11,7 +11,7 @@ const PageTitle: React.FC = ({ children }) => {
         width: '100%',
       },
       heading: {
-        fontSize: '40px',
+        fontSize: '32px',
         [theme.breakpoints.up('sm')]: {
           fontSize: '50px',
         },

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -15,9 +15,9 @@ const PageTitle: React.FC = ({ children }) => {
         [theme.breakpoints.up('sm')]: {
           fontSize: '50px',
         },
-        [theme.breakpoints.up('lg')]: {
-          fontSize: '60px',
-        },
+        // [theme.breakpoints.up('lg')]: {
+        //   fontSize: '60px',
+        // },
       },
     })
   );

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Typography, Box } from '@material-ui/core';
+import { Typography, Box, useMediaQuery } from '@material-ui/core';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
+import theme from '../common/styles/CMTheme';
 
 const PageTitle: React.FC = ({ children }) => {
   const useStyles = makeStyles((theme) =>
@@ -9,14 +10,25 @@ const PageTitle: React.FC = ({ children }) => {
         textAlign: 'center',
         width: '100%',
       },
+      heading: {
+        fontSize: '40px',
+        [theme.breakpoints.up('sm')]: {
+          fontSize: '50px',
+        },
+        [theme.breakpoints.up('lg')]: {
+          fontSize: '60px',
+        },
+      },
     })
   );
+
+  const isXSmall = useMediaQuery(theme.breakpoints.down('xs'));
 
   const classes = useStyles();
 
   return (
-    <Box py={3} className={classes.root}>
-      <Typography variant="h3" component="h1">
+    <Box py={isXSmall ? 4 : 8} className={classes.root}>
+      <Typography className={classes.heading} variant="h1" component="h1">
         {children}
       </Typography>
     </Box>

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -16,7 +16,9 @@ const PageTitle: React.FC = ({ children }) => {
 
   return (
     <Box py={3} className={classes.root}>
-      <Typography variant="h1">{children}</Typography>
+      <Typography variant="h3" component="h1">
+        {children}
+      </Typography>
     </Box>
   );
 };

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography } from '@material-ui/core';
+import { Typography, Box } from '@material-ui/core';
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 
 const PageTitle: React.FC = ({ children }) => {
@@ -7,6 +7,7 @@ const PageTitle: React.FC = ({ children }) => {
     createStyles({
       root: {
         textAlign: 'center',
+        width: '100%',
       },
     })
   );
@@ -14,9 +15,9 @@ const PageTitle: React.FC = ({ children }) => {
   const classes = useStyles();
 
   return (
-    <div className={classes.root}>
-      <Typography variant="h1">{children};</Typography>
-    </div>
+    <Box py={3} className={classes.root}>
+      <Typography variant="h1">{children}</Typography>
+    </Box>
   );
 };
 

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -26,44 +26,47 @@ const ClimateFeed: React.FC = () => {
 
           <PageTitle>Your Personal Climate Feed</PageTitle>
 
-          {React.Children.toArray(
-            data?.climateEffects.map((effect, i) => {
-              // TODO: Refactor below into a component
-              const preview = effect.effectSolutions[0];
-              return (
-                <div
-                  data-testid={`EffectCard-${effect.effectId}`}
-                  key={`value-${i}`}
-                >
-                  <Card
-                    header={
-                      <CardHeader
-                        title={effect.effectTitle}
-                        preTitle={effect?.isPossiblyLocal ? 'Local impact' : ''}
-                        isPossiblyLocal={effect.isPossiblyLocal}
-                      />
-                    }
-                    index={i}
-                    imageUrl={effect.imageUrl}
-                    footer={<EffectOverlay effect={effect} />}
-                    preview={
-                      <CardHeader
-                        title={preview.solutionTitle}
-                        preTitle={`${preview.solutionType} Action`}
-                        bgColor={COLORS.ACCENT2}
-                        index={i}
-                        cardIcon={preview.solutionType}
-                      />
-                    }
+          {data?.climateEffects &&
+            React.Children.toArray(
+              data?.climateEffects.map((effect, i) => {
+                // TODO: Refactor below into a component
+                const preview = effect.effectSolutions[0];
+                return (
+                  <div
+                    data-testid={`EffectCard-${effect.effectId}`}
+                    key={`value-${i}`}
                   >
-                    <Typography variant="body1">
-                      {effect.effectShortDescription}
-                    </Typography>
-                  </Card>
-                </div>
-              );
-            })
-          )}
+                    <Card
+                      header={
+                        <CardHeader
+                          title={effect.effectTitle}
+                          preTitle={
+                            effect?.isPossiblyLocal ? 'Local impact' : ''
+                          }
+                          isPossiblyLocal={effect.isPossiblyLocal}
+                        />
+                      }
+                      index={i}
+                      imageUrl={effect.imageUrl}
+                      footer={<EffectOverlay effect={effect} />}
+                      preview={
+                        <CardHeader
+                          title={preview.solutionTitle}
+                          preTitle={`${preview.solutionType} Action`}
+                          bgColor={COLORS.ACCENT2}
+                          index={i}
+                          cardIcon={preview.solutionType}
+                        />
+                      }
+                    >
+                      <Typography variant="body1">
+                        {effect.effectShortDescription}
+                      </Typography>
+                    </Card>
+                  </div>
+                );
+              })
+            )}
         </PageContent>
       </Wrapper>
     </>

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -1,118 +1,71 @@
+import { Typography } from '@material-ui/core';
 import React from 'react';
-import { Grid, makeStyles, Typography, Box } from '@material-ui/core';
 import { COLORS } from '../common/styles/CMTheme';
-import Loader from '../components/Loader';
 import Card from '../components/Card';
-import Error500 from '../pages/Error500';
-import Wrapper from '../components/Wrapper';
 import CardHeader from '../components/CardHeader';
 import EffectOverlay from '../components/EffectOverlay';
-import { useClimateFeed } from '../hooks/useClimateFeed';
+import Loader from '../components/Loader';
+import PageContent from '../components/PageContent';
+import PageTitle from '../components/PageTitle';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
-
-const useStyles = makeStyles({
-  root: {
-    flexGrow: 1,
-    minHeight: '100vh',
-    padding: 0,
-  },
-  feedContainer: {
-    padding: 0,
-  },
-  typography: {
-    textAlign: 'center',
-  },
-});
+import Wrapper from '../components/Wrapper';
+import { useClimateFeed } from '../hooks/useClimateFeed';
+import Error500 from '../pages/Error500';
 
 const ClimateFeed: React.FC = () => {
-  const classes = useStyles();
-
   const { data, isLoading, error } = useClimateFeed();
 
-  if (error) {
-    return <Error500 />;
-  }
+  if (error) return <Error500 />;
 
   return (
     <>
-      <Grid
-        container
-        className={classes.root}
-        data-testid="Myths Feed"
-        justify="space-between"
-      >
-        <Wrapper bgColor={COLORS.ACCENT5}>
-          <Grid item sm={false} lg={4}>
-            {/* left gutter */}
-          </Grid>
-
+      <ScrollToTopOnMount />
+      <Wrapper bgColor={COLORS.ACCENT5}>
+        <PageContent>
           {isLoading && <Loader />}
 
-          {data?.climateEffects && (
-            <Grid
-              container
-              item
-              xs={12}
-              sm={10}
-              md={8}
-              lg={6}
-              className={classes.root}
-              data-testid="ClimateFeed"
-              justify="space-around"
-            >
-              <Grid item className={classes.feedContainer}>
-                <Box my={3} px={1}>
-                  <Typography variant="h4">
-                    Your Personal Climate Feed
-                  </Typography>
-                </Box>
+          <PageTitle>Your Personal Climate Feed</PageTitle>
 
-                <ScrollToTopOnMount />
-                {data.climateEffects.map((effect, i) => {
-                  const preview = effect.effectSolutions[0];
-                  return (
-                    <div
-                      data-testid={`EffectCard-${effect.effectId}`}
-                      key={`value-${i}`}
-                    >
-                      <Card
-                        header={
-                          <CardHeader
-                            title={effect.effectTitle}
-                            preTitle={
-                              effect?.isPossiblyLocal ? 'Local impact' : ''
-                            }
-                            isPossiblyLocal={effect.isPossiblyLocal}
-                          />
-                        }
+          {React.Children.toArray(
+            data?.climateEffects.map((effect, i) => {
+              // TODO: Refactor below into a component
+              const preview = effect.effectSolutions[0];
+              return (
+                <div
+                  data-testid={`EffectCard-${effect.effectId}`}
+                  key={`value-${i}`}
+                >
+                  <Card
+                    header={
+                      <CardHeader
+                        title={effect.effectTitle}
+                        preTitle={effect?.isPossiblyLocal ? 'Local impact' : ''}
+                        isPossiblyLocal={effect.isPossiblyLocal}
+                      />
+                    }
+                    index={i}
+                    imageUrl={effect.imageUrl}
+                    footer={<EffectOverlay effect={effect} />}
+                    preview={
+                      <CardHeader
+                        title={preview.solutionTitle}
+                        preTitle={`${preview.solutionType} Action`}
+                        bgColor={COLORS.ACCENT2}
                         index={i}
-                        imageUrl={effect.imageUrl}
-                        footer={<EffectOverlay effect={effect} />}
-                        preview={
-                          <CardHeader
-                            title={preview.solutionTitle}
-                            preTitle={`${preview.solutionType} Action`}
-                            bgColor={COLORS.ACCENT2}
-                            index={i}
-                            cardIcon={preview.solutionType}
-                          />
-                        }
-                      >
-                        <Typography variant="body1">
-                          {effect.effectShortDescription}
-                        </Typography>
-                      </Card>
-                    </div>
-                  );
-                })}
-              </Grid>
-            </Grid>
+                        cardIcon={preview.solutionType}
+                      />
+                    }
+                  >
+                    <Typography variant="body1">
+                      {effect.effectShortDescription}
+                    </Typography>
+                  </Card>
+                </div>
+              );
+            })
           )}
-          <Grid item sm={false} lg={4}>
-            {/* right gutter */}
-          </Grid>
-        </Wrapper>
-      </Grid>
+        </PageContent>
+      </Wrapper>
     </>
   );
 };

--- a/src/pages/MythFeed.tsx
+++ b/src/pages/MythFeed.tsx
@@ -1,78 +1,37 @@
+import { Grid } from '@material-ui/core';
 import React from 'react';
 import { useQuery } from 'react-query';
 import { getMyths } from '../api/getMyths';
 import { COLORS } from '../common/styles/CMTheme';
-import { Typography, Grid, makeStyles, Box } from '@material-ui/core';
 import Loader from '../components/Loader';
-import Error500 from './Error500';
 import MythCard from '../components/MythCard';
-import Wrapper from '../components/Wrapper';
+import PageContent from '../components/PageContent';
+import PageTitle from '../components/PageTitle';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
-
-const styles = makeStyles({
-  root: {
-    flexGrow: 1,
-    minHeight: '100vh',
-    paddingBottom: 24,
-  },
-  callToActionSection: {
-    minHeight: '100vh',
-  },
-  typography: {
-    textAlign: 'center',
-  },
-});
+import Wrapper from '../components/Wrapper';
+import Error500 from './Error500';
 
 const MythFeed: React.FC = () => {
-  const classes = styles();
-
   const { data, isLoading, error } = useQuery('myths', getMyths);
 
   if (error) return <Error500 />;
 
   return (
-    <Grid
-      container
-      className={classes.root}
-      data-testid="Myths Feed"
-      justify="space-around"
-    >
+    <>
+      <ScrollToTopOnMount />
       <Wrapper bgColor={COLORS.ACCENT4}>
-        <Grid item sm={false} lg={4}>
-          {/* left gutter */}
-        </Grid>
+        <PageContent>
+          <PageTitle>Climate Mind is against misinformation.</PageTitle>
 
-        <ScrollToTopOnMount />
-
-        <Grid
-          item
-          xs={12}
-          sm={10}
-          md={8}
-          lg={6}
-          container
-          direction="row"
-          justify="space-between"
-          alignItems="center"
-        >
-          <Box my={3} px={1}>
-            <Typography variant="h4">
-              Climate Mind is against misinformation.
-            </Typography>
-          </Box>
-
-          <Grid item sm={12} lg={12} container>
+          <Grid container>
             {isLoading && <Loader />}
             {data?.myths.map((myth, i) => (
               <MythCard myth={myth} key={i} />
             ))}
           </Grid>
-        </Grid>
-        <Grid item sm={false} lg={4}>
-          {/* right gutter */}
-        </Grid>
+        </PageContent>
       </Wrapper>
-    </Grid>
+    </>
   );
 };
 

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useQuery } from 'react-query';
 import { getSolutions } from '../api/getSolutions';
 import { COLORS } from '../common/styles/CMTheme';
-import { Typography, Grid, makeStyles } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import Loader from '../components/Loader';
 import Card from '../components/Card';
 import CardHeader from '../components/CardHeader';
@@ -11,100 +11,45 @@ import Wrapper from '../components/Wrapper';
 import SolutionOverlay from '../components/SolutionOverlay';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 import PageTitle from '../components/PageTitle';
-
-const styles = makeStyles({
-  root: {
-    flexGrow: 1,
-    minHeight: '100vh',
-    paddingBottom: 16,
-  },
-  feedContainer: {
-    padding: 0,
-  },
-  callToActionSection: {
-    minHeight: '100vh',
-  },
-  typography: {
-    textAlign: 'center',
-  },
-  cardContent: {
-    fontFamily: 'Bilo',
-    fontSize: 16,
-    fontWeight: 500,
-    letterSpacing: 0,
-    lineHeight: '22pt',
-  },
-  spacing: {
-    marginTop: '-20px',
-    marginBottom: '20px',
-  },
-});
+import PageContent from '../components/PageContent';
 
 const SolutionsFeed: React.FC = () => {
-  const classes = styles();
-
   const { data, isLoading, error } = useQuery('solutions', getSolutions);
 
   if (error) return <Error500 />;
 
   return (
-    <Grid
-      container
-      className={classes.root}
-      data-testid="ClimateFeed"
-      justify="space-around"
-    >
-      <Wrapper bgColor={COLORS.ACCENT2} fullHeight>
-        <Grid item sm={false} lg={4}>
-          {/* left gutter */}
-        </Grid>
-
+    <Wrapper bgColor={COLORS.ACCENT2} fullHeight>
+      <PageContent>
         <ScrollToTopOnMount />
 
-        <Grid
-          item
-          xs={12}
-          sm={10}
-          md={8}
-          lg={6}
-          container
-          direction="row"
-          justify="center"
-          alignItems="center"
-        >
-          <PageTitle>Ready to take action?</PageTitle>
+        <PageTitle>Ready to take action?</PageTitle>
 
-          <Grid item sm={12} lg={12} className={classes.feedContainer}>
-            {isLoading && <Loader />}
-            {React.Children.toArray(
-              data?.solutions.map((solution, i) => (
-                <div data-testid={`ActionCard-${solution.iri}`}>
-                  <Card
-                    header={
-                      <CardHeader
-                        title={solution.solutionTitle}
-                        preTitle={`${solution.solutionType} action`}
-                      />
-                    }
-                    key={`value-${i}`}
-                    index={i}
-                    imageUrl={solution.imageUrl}
-                    footer={<SolutionOverlay solution={solution} />}
-                  >
-                    <Typography variant="body1">
-                      {solution.shortDescription}
-                    </Typography>
-                  </Card>
-                </div>
-              ))
-            )}
-          </Grid>
-        </Grid>
-        <Grid item sm={false} lg={4}>
-          {/* right gutter */}
-        </Grid>
-      </Wrapper>
-    </Grid>
+        {isLoading && <Loader />}
+        {React.Children.toArray(
+          data?.solutions.map((solution, i) => (
+            <div data-testid={`ActionCard-${solution.iri}`}>
+              <Card
+                header={
+                  <CardHeader
+                    title={solution.solutionTitle}
+                    preTitle={`${solution.solutionType} action`}
+                  />
+                }
+                key={`value-${i}`}
+                index={i}
+                imageUrl={solution.imageUrl}
+                footer={<SolutionOverlay solution={solution} />}
+              >
+                <Typography variant="body1">
+                  {solution.shortDescription}
+                </Typography>
+              </Card>
+            </div>
+          ))
+        )}
+      </PageContent>
+    </Wrapper>
   );
 };
 

--- a/src/pages/SolutionsFeed.tsx
+++ b/src/pages/SolutionsFeed.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useQuery } from 'react-query';
 import { getSolutions } from '../api/getSolutions';
 import { COLORS } from '../common/styles/CMTheme';
-import { Typography, Grid, makeStyles, Box } from '@material-ui/core';
+import { Typography, Grid, makeStyles } from '@material-ui/core';
 import Loader from '../components/Loader';
 import Card from '../components/Card';
 import CardHeader from '../components/CardHeader';
@@ -10,6 +10,7 @@ import Error500 from './Error500';
 import Wrapper from '../components/Wrapper';
 import SolutionOverlay from '../components/SolutionOverlay';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
+import PageTitle from '../components/PageTitle';
 
 const styles = makeStyles({
   root: {
@@ -71,9 +72,7 @@ const SolutionsFeed: React.FC = () => {
           justify="center"
           alignItems="center"
         >
-          <Box my={3} px={1} data-testid="next-box">
-            <Typography variant="h4">Ready to take action?</Typography>
-          </Box>
+          <PageTitle>Ready to take action?</PageTitle>
 
           <Grid item sm={12} lg={12} className={classes.feedContainer}>
             {isLoading && <Loader />}


### PR DESCRIPTION
# Update the Climate Feed, Solutions Feed and Myths feed to handle larger screens. 

This card resolves CM-528, CM-518, CM-529

 - Added **PageTitle** and **PageContent** components
 - PageTitle - Can have a different size at each MUI breakpoint
 - PageContent - Max Width of page content is 640px
 - Card Overlay now has a max width 640px
 - Added basic unit tests for new components
 - Added new components to Climate feed, Myth Feed, Solutions Feed

## Climate Feed 

<img width="368" alt="Screenshot 2021-03-21 at 11 37 10" src="https://user-images.githubusercontent.com/44759513/111903593-f9495100-8a3a-11eb-8aeb-e674591dfa01.png">
<img width="2560" alt="Screenshot 2021-03-21 at 11 36 31 (2)" src="https://user-images.githubusercontent.com/44759513/111903599-06fed680-8a3b-11eb-8549-1b113d871b58.png">

<img width="1752" alt="Screenshot 2021-03-21 at 11 46 36" src="https://user-images.githubusercontent.com/44759513/111903675-6230c900-8a3b-11eb-9b51-1057eaa8bf4e.png">


## Solutions Feed 

<img width="371" alt="Screenshot 2021-03-21 at 11 37 49" src="https://user-images.githubusercontent.com/44759513/111903635-3281c100-8a3b-11eb-8a82-45c501918608.png">
<img width="1647" alt="Screenshot 2021-03-21 at 11 37 32" src="https://user-images.githubusercontent.com/44759513/111903636-357cb180-8a3b-11eb-8cdc-6fb207200640.png">

## Myths Feed 

<img width="1648" alt="Screenshot 2021-03-21 at 11 38 16" src="https://user-images.githubusercontent.com/44759513/111903665-5218e980-8a3b-11eb-90a2-ec7ceabbc65e.png">
<img width="363" alt="Screenshot 2021-03-21 at 11 38 00" src="https://user-images.githubusercontent.com/44759513/111903667-5513da00-8a3b-11eb-8243-dc623f6e2da0.png">


