### PR TITLE
Fixed: Responsive menu gets wrong icon position for some screen sizes

### DIFF
--- a/src/components/AppBar/PageWithAppBottomBar.tsx
+++ b/src/components/AppBar/PageWithAppBottomBar.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const PageWithAppBottomBar: React.FC<Props> = ({ component }) => {
-  const isXS = useMediaQuery(theme.breakpoints.down('xs'));
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
   const menuLinks = [
     {
@@ -37,7 +37,7 @@ const PageWithAppBottomBar: React.FC<Props> = ({ component }) => {
 
   return (
     <>
-      {isXS ? 
+      {isSmall ? 
       (<>
         <AppBar />
         {component}


### PR DESCRIPTION
Behavior after fix:

![image](https://user-images.githubusercontent.com/10048951/115990709-ed662700-a5c4-11eb-873e-1b727ba8137a.png)
