### PR TITLE
Retaking the PVQ after completing 20 questions restarts the quiz at question 11

### DIFF
--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Slide from '@material-ui/core/Slide';
 import MailIcon from '@material-ui/icons/Mail';

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Slide from '@material-ui/core/Slide';
 import MailIcon from '@material-ui/icons/Mail';
@@ -14,6 +14,7 @@ import ROUTES from '../Router/RouteConfig';
 import { useSession } from '../../hooks/useSession';
 import { useResponses } from '../../hooks/useResponses';
 import { useClimatePersonality } from '../../hooks/useClimatePersonality';
+import { useQuestions } from '../../hooks/useQuestions';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -48,6 +49,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
   const { sessionId, clearSession } = useSession();
   const { dispatch } = useResponses();
   const { clearPersonality } = useClimatePersonality();
+  const { setCurrentSet } = useQuestions();
 
   // Handles opening the link in a new window
   const handleNavAway = (url: string) => {
@@ -65,13 +67,17 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
   };
 
   const handleRetakeQuiz = () => {
-    // Clear the session id
-    clearSession();
-    // Clear the questionnaire responses
-    dispatch({ type: 'CLEAR_RESPONSES' });
-    //Clear personalValues
-    clearPersonality();
-    // Redirect back to Questionaire Start
+     // Clear the session id
+     clearSession();
+     // Clear the questionnaire responses
+     dispatch({ type: 'CLEAR_RESPONSES' });
+     //Clear personalValues
+     clearPersonality();
+
+     // reset questions to set #1
+     if (setCurrentSet ) {
+       setCurrentSet(1);
+     }
     push(ROUTES.ROUTE_QUIZ);
   };
 


### PR DESCRIPTION
Bugfix: this issue appears because the set of questions was not reset when retaking quiz. Triggered in the MenuPaper component, the link to retake quiz:

![image](https://user-images.githubusercontent.com/10048951/116813603-c4114200-ab54-11eb-905f-5f60be1b4415.png)

Also fixes ticket CM-643 Trying to get personal values after retaking the quiz redirects to the front page