### PR TITLE
CM-700_FE__User_can_retake_quiz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   azure-acr: circleci/azure-acr@0.2.0
 jobs:
   build:
-    resource_class: medium+
     environment:
       CI: true
       NODE_OPTIONS: --max_old_space_size=8192
@@ -29,6 +28,7 @@ jobs:
             - .
 
   test:
+    resource_class: medium+
     docker:
       # The primary container is an instance of the first image listed. The job's commands run in this container.
       - image: cimg/node:current

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
   azure-acr: circleci/azure-acr@0.2.0
 jobs:
   build:
+    resource_class: medium+
     environment:
       CI: true
       NODE_OPTIONS: --max_old_space_size=8192

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
   build:
     environment:
       CI: true
-      NODE_OPTIONS: --max_old_space_size=8192
     # Reuse Docker container specification given by the node Orb
     executor: node/default
     steps:
@@ -28,7 +27,6 @@ jobs:
             - .
 
   test:
-    resource_class: medium+
     docker:
       # The primary container is an instance of the first image listed. The job's commands run in this container.
       - image: cimg/node:current
@@ -38,7 +36,7 @@ jobs:
           at: .
       - run:
           name: Test
-          command: npm test
+          command: npm run test:ci
 
 workflows:
   version: 2

--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -2,7 +2,7 @@
 
 import { terminalLog } from '../support/helpers';
 
-describe('Personal values page loads and looks correct', () => {
+describe.only('Personal values page loads and looks correct', () => {
   beforeEach(() => {
     cy.acceptCookies();
     cy.setSession();

--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -2,7 +2,7 @@
 
 import { terminalLog } from '../support/helpers';
 
-describe.only('Personal values page loads and looks correct', () => {
+describe('Personal values page loads and looks correct', () => {
   beforeEach(() => {
     cy.acceptCookies();
     cy.setSession();

--- a/nginx.config
+++ b/nginx.config
@@ -9,7 +9,7 @@ server {
         try_files $$uri /index.html;
     }
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' http://www.googletagmanager.com/ https://www.google-analytics.com/ 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://*.typekit.net; img-src * www.googletagmanager.com 'self' data:; font-src 'self' https://*.typekit.net data:; connect-src 'self' https://*.okta.com https://app-backend-prod-001.azurewebsites.net https://www.google-analytics.com ;";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' http://www.googletagmanager.com/ https://www.google-analytics.com/ 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://*.typekit.net; img-src * www.googletagmanager.com 'self' data:; font-src 'self' https://*.typekit.net https://fonts.googleapis.com data:; connect-src 'self' https://*.okta.com https://app-backend-prod-001.azurewebsites.net https://www.google-analytics.com ;";
     add_header Referrer-Policy "no-referrer, strict-origin-when-cross-origin";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     add_header X-Content-Type-Options nosniff;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
+    "test:ci": "react-scripts test --env=jsdom --maxWorkers=2",
     "eject": "react-scripts eject",
     "percy": "percy exec --config ./percy.yml -- cypress run",
     "cypress": "cypress run",

--- a/src/__tests__/src/SubmitSetOne.test.tsx
+++ b/src/__tests__/src/SubmitSetOne.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-window.scrollTo = jest.fn();
-
+import { QueryClient, QueryClientProvider } from 'react-query';
 import SubmitSetOne from '../../pages/SubmitSetOne';
 
+window.scrollTo = jest.fn();
+const queryClient = new QueryClient();
+
 // Mock react router to simulate history.push on button click
-jest.mock('react-router-dom', () => ({
+const mockHistoryPush = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useHistory: () => ({
-    push: jest.fn(),
+    push: mockHistoryPush,
   }),
 }));
 
@@ -45,14 +49,22 @@ describe('Submit Set One Page', () => {
     const climatePersonalityExp =
       'Do you want to carry on with another 10 questions or get your results now?';
 
-    const { getByText } = render(<SubmitSetOne />);
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <SubmitSetOne />
+      </QueryClientProvider>
+    );
 
     expect(getByText(welcomeText)).toBeInTheDocument();
     expect(getByText(climatePersonalityExp)).toBeInTheDocument();
   });
 
   it('the correct text shows', () => {
-    const { getByTestId } = render(<SubmitSetOne />);
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <SubmitSetOne />
+      </QueryClientProvider>
+    );
     const continueButton = getByTestId('continue-quiz-button');
     const finishButton = getByTestId('finish-quiz-button');
     expect(continueButton);

--- a/src/__tests__/src/SubmitSetTwo.test.tsx
+++ b/src/__tests__/src/SubmitSetTwo.test.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
 window.scrollTo = jest.fn();
+const queryClient = new QueryClient();
 
 import SubmitSetTwo from '../../pages/SubmitSetTwo';
 
 // Mock react router to simulate history.push on button click
-jest.mock('react-router-dom', () => ({
+const mockHistoryPush = jest.fn();
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useHistory: () => ({
-    push: jest.fn(),
+    push: mockHistoryPush,
   }),
 }));
 
@@ -42,12 +47,20 @@ jest.mock('../../hooks/useResponses', () => {
 describe('Submit Set One Page', () => {
   it('the correct text shows', () => {
     const headingText = /Woohoo! Good Job!/i;
-    const { getByText } = render(<SubmitSetTwo />);
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <SubmitSetTwo />
+      </QueryClientProvider>
+    );
     expect(getByText(headingText)).toBeInTheDocument();
   });
 
   it('It has the submit button', () => {
-    const { getByTestId } = render(<SubmitSetTwo />);
+    const { getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <SubmitSetTwo />
+      </QueryClientProvider>
+    );
     const finishButton = getByTestId('finish-quiz-button');
     expect(finishButton);
   });

--- a/src/api/postScores.ts
+++ b/src/api/postScores.ts
@@ -15,7 +15,7 @@ type Scores = {
 
 export async function submitScores(
   scores: Scores,
-  quizSessionId: string,
+  quizSessionId: string | null,
   jwt?: string
 ): Promise<TScoreSubmitResponse> {
   // Request body for Submission
@@ -40,7 +40,9 @@ export async function submitScores(
       headers: HEADERS,
     });
     const data = await response.data;
-    pushQuizFinishToDataLayer(data.sessionId, quizSessionId);
+    if (quizSessionId) {
+      pushQuizFinishToDataLayer(data.sessionId, quizSessionId);
+    }
     return data;
   } catch (err) {
     throw err;

--- a/src/api/postScores.ts
+++ b/src/api/postScores.ts
@@ -7,11 +7,6 @@ type TScoreSubmitResponse = {
   sessionId: string;
 };
 
-type TErrorResponse = {
-  error: string;
-  sessionId: null;
-};
-
 type Scores = {
   SetOne: TResponse[];
   SetTwo: TResponse[];
@@ -20,16 +15,20 @@ type Scores = {
 
 export async function submitScores(
   scores: Scores,
-  quizSessionId: string
-): Promise<TScoreSubmitResponse | TErrorResponse> {
+  quizSessionId: string,
+  jwt?: string
+): Promise<TScoreSubmitResponse> {
   // Request body for Submission
   const REQUEST_BODY = {
     questionResponses: {
       SetOne: [...scores.SetOne],
-      SetTwo: [...scores.SetTwo]
+      SetTwo: [...scores.SetTwo],
     },
     zipCode: scores.zipCode,
   };
+
+  // Auth token added for logged in user so that the session id can be assigned to the user
+  const HEADERS = { Authorization: jwt ? `Brearer ${jwt}` : '' };
 
   // Build the correct url
   const SCORE_ENDPOINT = '/scores';
@@ -37,15 +36,13 @@ export async function submitScores(
 
   // Try and make the request
   try {
-    const response = await axios.post(REQUEST_URL, REQUEST_BODY);
+    const response = await axios.post(REQUEST_URL, REQUEST_BODY, {
+      headers: HEADERS,
+    });
     const data = await response.data;
     pushQuizFinishToDataLayer(data.sessionId, quizSessionId);
     return data;
   } catch (err) {
-    console.error(err);
-    return {
-      error: err.message,
-      sessionId: null,
-    };
+    throw err;
   }
 }

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -118,7 +118,6 @@ const BottomMenu: React.FC<BottomMenuProps> = ({
   useNoSessionRedirect();
 
   const handleChange = (event: any, newValue: React.SetStateAction<string>) => {
-    console.log({ newValue });
     setState(newValue);
     history.push(`${newValue}`);
   };

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -111,8 +111,11 @@ export function useAuth() {
 
   const isLoggedIn = auth.isLoggedIn;
 
+  const accessToken = auth.accessToken;
+
   return {
     auth,
+    accessToken,
     setUser,
     login,
     logout,

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -91,7 +91,6 @@ export function useAuth() {
   };
 
   const logout = async () => {
-    console.log('loggin out now');
     // Clear out user details from state
     if (setAuth) {
       setAuth(emptyUser);

--- a/src/hooks/usePostScores.tsx
+++ b/src/hooks/usePostScores.tsx
@@ -1,0 +1,60 @@
+import { useMutation } from 'react-query';
+import { useHistory } from 'react-router-dom';
+import { submitScores } from '../api/postScores';
+import ROUTES from '../components/Router/RouteConfig';
+import { useAuth } from '../hooks/useAuth';
+import { useResponses } from '../hooks/useResponses';
+import { useSession } from '../hooks/useSession';
+import { useToast } from './useToast';
+
+export function usePostScores() {
+  const { quizSessionId, setSessionId } = useSession();
+  const { push } = useHistory();
+  const { showToast } = useToast();
+  const { accessToken } = useAuth();
+  const quizResponses = useResponses();
+
+  const SCORES = {
+    SetOne: quizResponses.state.SetOne,
+    SetTwo: quizResponses.state.SetTwo,
+    zipCode: null,
+  };
+
+  const mutation = useMutation(
+    () => submitScores(SCORES, quizSessionId, accessToken),
+    {
+      onError: (error: any) => {
+        showToast({
+          message: error.response?.data?.error || 'Unknow Error has occoured',
+          type: 'error',
+        });
+      },
+      onSuccess: (response: { sessionId: string }) => {
+        // Show Success Message
+        showToast({
+          message: 'Submitted',
+          type: 'success',
+        });
+
+        // Set the session id
+        setSessionId(response.sessionId);
+        // Push the user to the correct page
+        push(ROUTES.ROUTE_LOCATION);
+      },
+    }
+  );
+
+  const { isLoading, isError, mutateAsync, isSuccess, error } = mutation;
+
+  const postScores = async () => {
+    await mutateAsync();
+  };
+
+  return {
+    postScores,
+    isLoading,
+    isSuccess,
+    isError,
+    error,
+  };
+}

--- a/src/hooks/usePostScores.tsx
+++ b/src/hooks/usePostScores.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { submitScores } from '../api/postScores';
 import ROUTES from '../components/Router/RouteConfig';
 import { useAuth } from '../hooks/useAuth';
-import { useResponses } from '../hooks/useResponses';
+import { useResponsesData } from '../hooks/useResponses';
 import { useSession } from '../hooks/useSession';
 import { useToast } from './useToast';
 
@@ -12,11 +12,11 @@ export function usePostScores() {
   const { push } = useHistory();
   const { showToast } = useToast();
   const { accessToken } = useAuth();
-  const quizResponses = useResponses();
+  const quizResponses = useResponsesData();
 
   const SCORES = {
-    SetOne: quizResponses.state.SetOne,
-    SetTwo: quizResponses.state.SetTwo,
+    SetOne: quizResponses.SetOne,
+    SetTwo: quizResponses.SetTwo,
     zipCode: null,
   };
 

--- a/src/hooks/usePostScores.tsx
+++ b/src/hooks/usePostScores.tsx
@@ -32,14 +32,14 @@ export function usePostScores() {
       onSuccess: (response: { sessionId: string }) => {
         // Show Success Message
         showToast({
-          message: 'Submitted',
+          message: 'Scores Registered',
           type: 'success',
         });
 
         // Set the session id
         setSessionId(response.sessionId);
         // Push the user to the correct page
-        push(ROUTES.ROUTE_LOCATION);
+        push(ROUTES.ROUTE_VALUES);
       },
     }
   );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,8 +1,10 @@
 import { Box, createStyles, makeStyles, Typography } from '@material-ui/core';
 import { useFormik } from 'formik';
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import { ReactComponent as Logo } from '../assets/cm-logo.svg';
 import { COLORS } from '../common/styles/CMTheme';
+import ROUTES from '../components/Router/RouteConfig';
 import Button from '../components/Button';
 import PageContent from '../components/PageContent';
 import PageTitle from '../components/PageTitle';
@@ -24,7 +26,12 @@ const useStyles = makeStyles(() =>
 // LoginPage Component
 const LoginPage: React.FC = () => {
   const classes = useStyles();
-  const { login } = useAuth();
+  const { login, isLoggedIn } = useAuth();
+  const { push } = useHistory();
+
+  if (isLoggedIn) {
+    push(ROUTES.ROUTE_FEED);
+  }
 
   // Set initial form values and handle submission
   const formik = useFormik({

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,6 +1,7 @@
 import { Box, createStyles, makeStyles, Typography } from '@material-ui/core';
 import { useFormik } from 'formik';
 import React from 'react';
+import ROUTES from '../components/Router/RouteConfig';
 import { useHistory } from 'react-router-dom';
 import { COLORS } from '../common/styles/CMTheme';
 import Button from '../components/Button';
@@ -11,6 +12,7 @@ import Wrapper from '../components/Wrapper';
 import { registerSchema } from '../helpers/validationSchemas';
 import { useRegister } from '../hooks/useRegister';
 import { useSession } from '../hooks/useSession';
+import { useAuth } from '../hooks/useAuth';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -39,6 +41,12 @@ const RegistrationPage: React.FC = () => {
   const { register } = useRegister();
   const { push } = useHistory();
   const { sessionId } = useSession();
+  const { isLoggedIn } = useAuth();
+
+  // if a logged in user is doing the quiz again they should be redirected away from this page
+  if (isLoggedIn) {
+    push(ROUTES.ROUTE_FEED);
+  }
 
   // Formik used for form validation and submission
   const formik = useFormik({

--- a/src/pages/SubmitSetOne.tsx
+++ b/src/pages/SubmitSetOne.tsx
@@ -1,55 +1,24 @@
 import { Box, Typography } from '@material-ui/core';
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { submitScores } from '../api/postScores';
 import { COLORS } from '../common/styles/CMTheme';
 import Button from '../components/Button';
 import PageContentFlex from '../components/PageContentFlex';
 import PageTitle from '../components/PageTitle';
-
-import ROUTES from '../components/Router/RouteConfig';
 import Wrapper from '../components/Wrapper';
-import { useClimatePersonality } from '../hooks/useClimatePersonality';
+import { usePostScores } from '../hooks/usePostScores';
 import { useQuestions } from '../hooks/useQuestions';
-import { useResponsesData } from '../hooks/useResponses';
-import { useSession } from '../hooks/useSession';
-import { TResponse } from '../types/types';
 
 const SubmitSetOne: React.FC<{}> = () => {
   const { push } = useHistory();
-  const history = useHistory();
-  const quizResponses = useResponsesData();
-  const { setSessionId, zipCode, quizSessionId } = useSession();
-  const { setPersonalValuesError } = useClimatePersonality();
   const { currentSet, setCurrentSet } = useQuestions();
+  const { postScores, isLoading } = usePostScores();
 
   useEffect(() => {
     if (currentSet === 2) {
       push('/questionnaire');
     }
   }, [currentSet, push]);
-
-  const handleSubmit = async () => {
-    // Submit my scores
-    if (quizSessionId) {
-      const SetOne = quizResponses.SetOne;
-      const SetTwo: TResponse[] = [];
-      const response = await submitScores(
-        { SetOne, SetTwo, zipCode },
-        quizSessionId
-      );
-      // Set the Session id
-      if (response && response.sessionId && setSessionId) {
-        const sessionId = response.sessionId;
-        setSessionId(sessionId);
-      } else {
-        setPersonalValuesError();
-        // throw new Error('Failed to submit scores');
-      }
-      // Navigate to the climate personality page
-    }
-    history.push(ROUTES.ROUTE_VALUES);
-  };
 
   const handleFinishSetTwo = () => {
     // switch to set 2 of questions
@@ -74,7 +43,8 @@ const SubmitSetOne: React.FC<{}> = () => {
         <Box mt={1}>
           <Typography variant="body1" align="center">
             <Button
-              onClick={handleSubmit}
+              disabled={isLoading}
+              onClick={postScores}
               id="submitButton"
               data-testid="continue-quiz-button"
             >
@@ -92,7 +62,7 @@ const SubmitSetOne: React.FC<{}> = () => {
 
         <Box component="div">
           <Button
-            disabled={false}
+            disabled={isLoading}
             color="primary"
             onClick={handleFinishSetTwo}
             variant="contained"

--- a/src/pages/SubmitSetTwo.tsx
+++ b/src/pages/SubmitSetTwo.tsx
@@ -1,45 +1,15 @@
 import { Box, Typography } from '@material-ui/core';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
-import { submitScores } from '../api/postScores';
 import { ReactComponent as RewardsIcon } from '../assets/reward-personalities.svg';
 import Button from '../components/Button';
 import PageContentFlex from '../components/PageContentFlex';
 import PageTitle from '../components/PageTitle';
-import ROUTES from '../components/Router/RouteConfig';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 import Wrapper from '../components/Wrapper';
-import { useClimatePersonality } from '../hooks/useClimatePersonality';
-import { useResponsesData } from '../hooks/useResponses';
-import { useSession } from '../hooks/useSession';
+import { usePostScores } from '../hooks/usePostScores';
 
 const SubmitSetTwo: React.FC<{}> = () => {
-  const history = useHistory();
-  const quizResponses = useResponsesData();
-  const { setSessionId, zipCode, quizSessionId } = useSession();
-  const { setPersonalValuesError } = useClimatePersonality();
-
-  const handleSubmit = async () => {
-    // Submit my scores
-    if (quizSessionId) {
-      const SetOne = quizResponses.SetOne;
-      const SetTwo = quizResponses.SetTwo;
-      const response = await submitScores(
-        { SetOne, SetTwo, zipCode },
-        quizSessionId
-      );
-      // Set the Session id
-      if (response && response.sessionId && setSessionId) {
-        const sessionId = response.sessionId;
-        setSessionId(sessionId);
-      } else {
-        setPersonalValuesError();
-        // throw new Error('Failed to submit scores');
-      }
-      // Navigate to the climate personality page
-      history.push(ROUTES.ROUTE_VALUES);
-    }
-  };
+  const { postScores, isLoading } = usePostScores();
 
   return (
     <>
@@ -68,12 +38,13 @@ const SubmitSetTwo: React.FC<{}> = () => {
 
           <Box>
             <Button
+              disabled={isLoading}
               id="submitButton"
               variant="contained"
               color="primary"
               fullWidth
               disableElevation
-              onClick={handleSubmit}
+              onClick={postScores}
               data-testid="finish-quiz-button"
             >
               Find out my Climate Personality


### PR DESCRIPTION
# All the user to retake the quiz. 

To allow the user to retake the quiz and get the correct feed back the we need to update the users session id. In order to do this the backend have updated the scores endpoint. When a user is authenticated the JWT should be passed with the call to `/scores`. The backend will then assign the user id in the token to the sessionId. 

To do this the following was done. 
- Updated the post scores function to allow the token to be optionally passed
- Refactored the posting scores logic into a hook `usePostScores` so that it user react-query and is just a bit neater in generel.
- When a the user is logged in the header is now passed with the api call:
`Authorization : Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`
- Set the sessionId in the front end when a new sessionId is received
- update the Registation and login pages to direct a logged in user away to the climate feed.
- Updated csp in nginx config as google fonts is being blocked test env

FINALLY: To fix the failing unit tests (using too much memory in CI) a new npm script was added to limit the number of threads jest can use in ci. 