### PR TITLE
Cm 629 update top menu drawer for desktop design

### DIFF
--- a/src/__tests__/src/__components__/AppBar.test.tsx
+++ b/src/__tests__/src/__components__/AppBar.test.tsx
@@ -32,7 +32,7 @@ describe('AppBar', () => {
     const button = getByRole('button');
     fireEvent.click(button);
     await wait(() => {
-      expect(getByTestId('TopMenuPaper')).toBeInTheDocument();
+      expect(getByTestId('TopMenuDrawer')).toBeInTheDocument();
       expect(getByText(/About ClimateMind/i)).toBeInTheDocument();
       expect(getByText(/Scientists Speak Up/i)).toBeInTheDocument();
       expect(getByTestId('socials')).toBeInTheDocument();

--- a/src/__tests__/src/__components__/AppBarWithMenu.test.tsx
+++ b/src/__tests__/src/__components__/AppBarWithMenu.test.tsx
@@ -76,7 +76,7 @@ describe('AppBarWithMenu', () => {
     const button = getByRole('button');
     fireEvent.click(button);
     await wait(() => {
-      expect(getByTestId('TopMenuPaper')).toBeInTheDocument();
+      expect(getByTestId('TopMenuDrawer')).toBeInTheDocument();
       expect(getByText(/About ClimateMind/i)).toBeInTheDocument();
       expect(getByText(/Scientists Speak Up/i)).toBeInTheDocument();
       expect(getByTestId('socials')).toBeInTheDocument();

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -24,7 +24,6 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
-      // zIndex: (props: StyleProps) => (props.isMenuShowing ? 10100 : 1301),
       zIndex: (props: StyleProps) => (props.isMenuShowing ? 10100 : 1000),
       position: 'relative',
     },
@@ -89,8 +88,6 @@ const CmAppBar: React.FC = () => {
         </Slide>
       </div>
 
-      {/* <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
-      {/* <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
       {isSmall ? 
         <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> : <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} />
       }

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import MenuIcon from '@material-ui/icons/Menu';
-import { Grid } from '@material-ui/core';
+import { Grid, useMediaQuery } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import MenuPaper from './MenuPaper';
+import MenuDrawer from './MenuDrawer';
 import AccountIcon from '../AccountIcon';
 import {
   useScrollTrigger,
@@ -13,6 +14,7 @@ import {
   AppBar,
   Slide,
 } from '@material-ui/core';
+import theme from '../../common/styles/CMTheme';
 
 interface StyleProps {
   isMenuShowing: boolean;
@@ -39,6 +41,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 const CmAppBar: React.FC = () => {
   const [isMenuShowing, setMenu] = useState(false);
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const classes = useStyles({ isMenuShowing });
   const trigger = useScrollTrigger();
 
@@ -85,7 +88,11 @@ const CmAppBar: React.FC = () => {
         </Slide>
       </div>
 
-      <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} />
+      {/* <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
+      {/* <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
+      {isSmall ? 
+        <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> : <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} />
+      }
     </>
   );
 };

--- a/src/components/AppBar/AppBar.tsx
+++ b/src/components/AppBar/AppBar.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
+      // zIndex: (props: StyleProps) => (props.isMenuShowing ? 10100 : 1301),
       zIndex: (props: StyleProps) => (props.isMenuShowing ? 10100 : 1000),
       position: 'relative',
     },

--- a/src/components/AppBar/AppBarWithMenu.tsx
+++ b/src/components/AppBar/AppBarWithMenu.tsx
@@ -40,7 +40,6 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
-      // zIndex: (props: StyleProps) => (props.isMenuShowing ? 10001 : 1301),
       zIndex: (props: StyleProps) => (props.isMenuShowing ? 10100 : 1000),
       position: 'relative',
     },

--- a/src/components/AppBar/AppBarWithMenu.tsx
+++ b/src/components/AppBar/AppBarWithMenu.tsx
@@ -2,11 +2,9 @@ import {
   AppBar,
   Grid,
   IconButton,
-  Slide,
   Tab,
   Tabs,
   useMediaQuery,
-  useScrollTrigger,
 } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import AnnouncementIcon from '@material-ui/icons/Announcement';
@@ -42,6 +40,7 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
+      // zIndex: (props: StyleProps) => (props.isMenuShowing ? 10001 : 1301),
       zIndex: (props: StyleProps) => (props.isMenuShowing ? 10100 : 1000),
       position: 'relative',
     },
@@ -62,7 +61,6 @@ const CmAppBarWithMenu: React.FC<AppBarWithMenuProps> = ({
 }: AppBarWithMenuProps) => {
   const [isMenuShowing, setMenu] = useState(false);
   const classes = useStyles({ isMenuShowing });
-  const trigger = useScrollTrigger();
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const iconStyle = { height: '20px' };
 
@@ -116,60 +114,56 @@ const CmAppBarWithMenu: React.FC<AppBarWithMenuProps> = ({
   return (
     <>
       <div className={classes.root}>
-        <Slide in={!trigger}>
-          <AppBar
-            position="fixed"
-            color="default"
-            data-testid="AppBarWithMenu"
-            id="AppBar"
-            aria-label="Climate Mind"
+        <AppBar
+          position="fixed"
+          color="default"
+          data-testid="AppBarWithMenu"
+          id="AppBar"
+          aria-label="Climate Mind"
+        >
+          <Grid
+            container
+            direction="row"
+            justify="center"
+            alignItems="center"
           >
-            <Grid
-              container
-              direction="row"
-              justify="center"
-              alignItems="center"
-            >
-              <Grid item>
-                <AccountIcon />
-              </Grid>
-
-              <Grid>
-                <Tabs value={value} onChange={handleChange} centered>
-                  {links.map((item) => (
-                    <Tab
-                      key={item.index}
-                      label={
-                        <span className={classes.tabLabel}>{item.label}</span>
-                      }
-                      icon={getIcon(item.value)}
-                      component={RouterLink}
-                      to={item.value}
-                    />
-                  ))}
-                </Tabs>
-              </Grid>
-              <Grid className={classes.rightCol}>
-                <IconButton
-                  edge="start"
-                  id="TopMenuToggle"
-                  color="inherit"
-                  aria-label="menu"
-                  aria-expanded={isMenuShowing}
-                  onClick={handleMenu}
-                >
-                  {isMenuShowing ? <CloseIcon /> : <MenuIcon />}
-                </IconButton>
-              </Grid>
+            <Grid item>
+              <AccountIcon />
             </Grid>
-          </AppBar>
-        </Slide>
+
+            <Grid>
+              <Tabs value={value} onChange={handleChange} centered>
+                {links.map((item) => (
+                  <Tab
+                    key={item.index}
+                    label={
+                      <span className={classes.tabLabel}>{item.label}</span>
+                    }
+                    icon={getIcon(item.value)}
+                    component={RouterLink}
+                    to={item.value}
+                  />
+                ))}
+              </Tabs>
+            </Grid>
+            <Grid className={classes.rightCol}>
+              <IconButton
+                edge="start"
+                id="TopMenuToggle"
+                color="inherit"
+                aria-label="menu"
+                aria-expanded={isMenuShowing}
+                onClick={handleMenu}
+              >
+                {isMenuShowing ? <CloseIcon /> : <MenuIcon />}
+              </IconButton>
+            </Grid>
+          </Grid>
+        </AppBar>
       </div>
       {isSmall ? 
         <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> : <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} />
       }
-      {/* <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
-      {/* <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
     </>
   );
 };

--- a/src/components/AppBar/AppBarWithMenu.tsx
+++ b/src/components/AppBar/AppBarWithMenu.tsx
@@ -5,6 +5,7 @@ import {
   Slide,
   Tab,
   Tabs,
+  useMediaQuery,
   useScrollTrigger,
 } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
@@ -20,6 +21,8 @@ import { Link as RouterLink } from 'react-router-dom';
 import { useNoSessionRedirect } from '../../hooks/useNoSessionRedirect';
 import AccountIcon from '../AccountIcon';
 import MenuPaper from './MenuPaper';
+import MenuDrawer from './MenuDrawer';
+import theme from '../../common/styles/CMTheme';
 
 interface Link {
   label: string;
@@ -60,6 +63,7 @@ const CmAppBarWithMenu: React.FC<AppBarWithMenuProps> = ({
   const [isMenuShowing, setMenu] = useState(false);
   const classes = useStyles({ isMenuShowing });
   const trigger = useScrollTrigger();
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
   const iconStyle = { height: '20px' };
 
   //supported icons
@@ -161,8 +165,11 @@ const CmAppBarWithMenu: React.FC<AppBarWithMenuProps> = ({
           </AppBar>
         </Slide>
       </div>
-
-      <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} />
+      {isSmall ? 
+        <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> : <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} />
+      }
+      {/* <MenuPaper isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
+      {/* <MenuDrawer isShowing={isMenuShowing} setIsShowing={setMenu} /> */}
     </>
   );
 };

--- a/src/components/AppBar/MenuDrawer.tsx
+++ b/src/components/AppBar/MenuDrawer.tsx
@@ -94,6 +94,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
         classes={{
           paper: classes.drawerPaper,
         }}
+        data-testid="TopMenuDrawer"
       >
         <Grid 
           container
@@ -175,7 +176,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                 Email Us
               </Button>
             </Grid>
-          </Grid>
+          </Grid>TopMenuPaper
         </Grid>
       </Drawer>
     </>

--- a/src/components/AppBar/MenuDrawer.tsx
+++ b/src/components/AppBar/MenuDrawer.tsx
@@ -1,4 +1,11 @@
-import { Button, Drawer, Grid, List, ListItem, ListItemText } from '@material-ui/core';
+import {
+  Button,
+  Drawer,
+  Grid,
+  List,
+  ListItem,
+  ListItemText,
+} from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React from 'react';
 import MailIcon from '@material-ui/icons/Mail';
@@ -24,13 +31,13 @@ const useStyles = makeStyles((theme: Theme) =>
       paddingLeft: theme.spacing(2),
     },
     drawerContainer: {
-      height: 'calc(100vh - 80px)', 
+      height: 'calc(100vh - 80px)',
     },
     drawerListItem: {
       cursor: 'pointer',
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
-      }
+      },
     },
     // MuiListItem-root
     menuEmail: {
@@ -48,7 +55,7 @@ const menuLinks = [
   { text: 'About ClimateMind', url: 'https://climatemind.org/' },
   { text: 'Scientists Speak Up', url: 'https://scientistsspeakup.org/' },
 ];
-  
+
 const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
   const classes = useStyles();
   const { push } = useHistory();
@@ -87,23 +94,23 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
 
   return (
     <>
-      <Drawer 
-        anchor={'right'}    
-        open={isShowing} 
-        className={classes.menuDrawer} 
+      <Drawer
+        anchor={'right'}
+        open={isShowing}
+        className={classes.menuDrawer}
         classes={{
           paper: classes.drawerPaper,
         }}
         data-testid="TopMenuDrawer"
       >
-        <Grid 
+        <Grid
           container
           direction="column"
           justify="space-between"
-          className={classes.drawerContainer} 
+          className={classes.drawerContainer}
         >
           {/* Grid item -> float to top */}
-          <Grid item >
+          <Grid item>
             <List>
               {/* Personal Values option should only show if there is a session id */}
               {sessionId && (
@@ -111,7 +118,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                   <ListItem
                     component="li"
                     disableGutters={true}
-                    className={classes.drawerListItem} 
+                    className={classes.drawerListItem}
                     onClick={() => handleNav(ROUTES.ROUTE_VALUES)}
                   >
                     <ListItemText primary="Personal Values" />
@@ -119,7 +126,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                   <ListItem
                     component="li"
                     disableGutters={true}
-                    className={classes.drawerListItem} 
+                    className={classes.drawerListItem}
                     onClick={handleRetakeQuiz}
                   >
                     <ListItemText primary="Re-take the Quiz" />
@@ -134,7 +141,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                   key={index}
                   disableGutters={true}
                   onClick={() => handleNavAway(item.url)}
-                  className={classes.drawerListItem} 
+                  className={classes.drawerListItem}
                 >
                   <ListItemText primary={item.text} />
                 </ListItem>
@@ -143,7 +150,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
               <ListItem
                 component="li"
                 disableGutters={true}
-                className={classes.drawerListItem} 
+                className={classes.drawerListItem}
                 onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
               >
                 <ListItemText primary="Privacy Policy" />
@@ -152,7 +159,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
           </Grid>
 
           {/* Grid item -> float to bottom */}
-          <Grid item> 
+          <Grid item>
             {/* Social Media Links*/}
             <Socials />
 
@@ -176,7 +183,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                 Email Us
               </Button>
             </Grid>
-          </Grid>TopMenuPaper
+          </Grid>
         </Grid>
       </Drawer>
     </>

--- a/src/components/AppBar/MenuDrawer.tsx
+++ b/src/components/AppBar/MenuDrawer.tsx
@@ -1,4 +1,4 @@
-import { Button, Drawer, Grid, List, ListItem, ListItemText, MenuItem } from '@material-ui/core';
+import { Button, Drawer, Grid, List, ListItem, ListItemText } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React from 'react';
 import MailIcon from '@material-ui/icons/Mail';
@@ -7,7 +7,6 @@ import MenuLoginLogout from './MenuLoginLogout';
 import ROUTES from '../Router/RouteConfig';
 import Socials from './Socials';
 import { useAuth } from '../../hooks/useAuth';
-import { red } from '@material-ui/core/colors';
 import { useQuestions } from '../../hooks/useQuestions';
 import { useResponses } from '../../hooks/useResponses';
 import { useHistory } from 'react-router-dom';
@@ -16,26 +15,19 @@ import { useClimatePersonality } from '../../hooks/useClimatePersonality';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     menuDrawer: {
-      // padding: '0',
       width: 360,
       flexShrink: 0,
-      // top: 0,
-      // left: 0,
-      // height: '100%',
     },
     drawerPaper: {
       width: 360,
       paddingTop: theme.spacing(7),
       paddingLeft: theme.spacing(2),
-      border: '1px solid red',
     },
     drawerContainer: {
-      border: "solid 1px", 
       height: 'calc(100vh - 80px)', 
     },
     drawerListItem: {
       cursor: 'pointer',
-      border: '1px solid grey',
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       }
@@ -46,7 +38,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
   })
 );
-
 
 export interface MenuDrawerProps {
   isShowing: boolean;
@@ -76,10 +67,6 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
 
   const handleNav = (url: string) => {
     push(url);
-    setIsShowing(false);
-  };
-
-  const handleClose = () => {
     setIsShowing(false);
   };
 
@@ -123,6 +110,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                   <ListItem
                     component="li"
                     disableGutters={true}
+                    className={classes.drawerListItem} 
                     onClick={() => handleNav(ROUTES.ROUTE_VALUES)}
                   >
                     <ListItemText primary="Personal Values" />
@@ -130,6 +118,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                   <ListItem
                     component="li"
                     disableGutters={true}
+                    className={classes.drawerListItem} 
                     onClick={handleRetakeQuiz}
                   >
                     <ListItemText primary="Re-take the Quiz" />
@@ -144,6 +133,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                   key={index}
                   disableGutters={true}
                   onClick={() => handleNavAway(item.url)}
+                  className={classes.drawerListItem} 
                 >
                   <ListItemText primary={item.text} />
                 </ListItem>
@@ -153,7 +143,6 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
                 component="li"
                 disableGutters={true}
                 className={classes.drawerListItem} 
-                // style={{cursor: 'pointer'}}
                 onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
               >
                 <ListItemText primary="Privacy Policy" />

--- a/src/components/AppBar/MenuDrawer.tsx
+++ b/src/components/AppBar/MenuDrawer.tsx
@@ -1,0 +1,186 @@
+import { Button, Drawer, Grid, List, ListItem, ListItemText, MenuItem } from '@material-ui/core';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import React from 'react';
+import MailIcon from '@material-ui/icons/Mail';
+import { useSession } from '../../hooks/useSession';
+import MenuLoginLogout from './MenuLoginLogout';
+import ROUTES from '../Router/RouteConfig';
+import Socials from './Socials';
+import { useAuth } from '../../hooks/useAuth';
+import { red } from '@material-ui/core/colors';
+import { useQuestions } from '../../hooks/useQuestions';
+import { useResponses } from '../../hooks/useResponses';
+import { useHistory } from 'react-router-dom';
+import { useClimatePersonality } from '../../hooks/useClimatePersonality';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    menuDrawer: {
+      // padding: '0',
+      width: 360,
+      flexShrink: 0,
+      // top: 0,
+      // left: 0,
+      // height: '100%',
+    },
+    drawerPaper: {
+      width: 360,
+      paddingTop: theme.spacing(7),
+      paddingLeft: theme.spacing(2),
+      border: '1px solid red',
+    },
+    drawerContainer: {
+      border: "solid 1px", 
+      height: 'calc(100vh - 80px)', 
+    },
+    menuEmail: {
+      marginTop: '1em',
+    },
+  })
+);
+
+
+export interface MenuDrawerProps {
+  isShowing: boolean;
+  setIsShowing: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const menuLinks = [
+  { text: 'About ClimateMind', url: 'https://climatemind.org/' },
+  { text: 'Scientists Speak Up', url: 'https://scientistsspeakup.org/' },
+];
+  
+const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
+  const classes = useStyles();
+  const { push } = useHistory();
+  const { sessionId, clearSession } = useSession();
+  const { setCurrentSet } = useQuestions();
+  const { dispatch } = useResponses();
+  const { clearPersonality } = useClimatePersonality();
+  const { auth } = useAuth();
+  const { isLoggedIn } = auth;
+
+  // Handles opening the link in a new window
+  const handleNavAway = (url: string) => {
+    window.open(url);
+    setIsShowing(false);
+  };
+
+  const handleNav = (url: string) => {
+    push(url);
+    setIsShowing(false);
+  };
+
+  const handleClose = () => {
+    setIsShowing(false);
+  };
+
+  const handleRetakeQuiz = () => {
+    // Clear the session id
+    clearSession();
+    // Clear the questionnaire responses
+    dispatch({ type: 'CLEAR_RESPONSES' });
+    //Clear personalValues
+    clearPersonality();
+
+    // reset questions to set #1
+    if (setCurrentSet) {
+      setCurrentSet(1);
+    }
+    push(ROUTES.ROUTE_QUIZ);
+  };
+
+  return (
+    <>
+      <Drawer 
+        anchor={'right'}    
+        open={isShowing} 
+        className={classes.menuDrawer} 
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+      >
+        <Grid 
+          container
+          direction="column"
+          justify="space-between"
+          className={classes.drawerContainer} 
+        >
+          {/* Grid item -> float to top */}
+          <Grid item >
+            <List>
+              {/* Personal Values option should only show if there is a session id */}
+              {sessionId && (
+                <>
+                  <ListItem
+                    component="li"
+                    disableGutters={true}
+                    onClick={() => handleNav(ROUTES.ROUTE_VALUES)}
+                  >
+                    <ListItemText primary="Personal Values" />
+                  </ListItem>
+                  <ListItem
+                    component="li"
+                    disableGutters={true}
+                    onClick={handleRetakeQuiz}
+                  >
+                    <ListItemText primary="Re-take the Quiz" />
+                  </ListItem>
+                </>
+              )}
+
+              {/* Menu List Items  */}
+              {menuLinks.map((item, index) => (
+                <ListItem
+                  component="li"
+                  key={index}
+                  disableGutters={true}
+                  onClick={() => handleNavAway(item.url)}
+                >
+                  <ListItemText primary={item.text} />
+                </ListItem>
+              ))}
+              {/* Privacy Policy */}
+              <ListItem
+                component="li"
+                disableGutters={true}
+                onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
+              >
+                <ListItemText primary="Privacy Policy" />
+              </ListItem>
+            </List>
+          </Grid>
+
+          {/* Grid item -> float to bottom */}
+          <Grid item> 
+            {/* Social Media Links*/}
+            <Socials />
+
+            {/* Login / Logout Buttons */}
+            <Grid item className={classes.menuEmail}>
+              <MenuLoginLogout
+                isLoggedIn={isLoggedIn}
+                setMenuIsShowing={setIsShowing}
+              />
+            </Grid>
+
+            {/* Email Us Button */}
+            <Grid item className={classes.menuEmail}>
+              <Button
+                variant="contained"
+                color="primary"
+                startIcon={<MailIcon />}
+                disableElevation
+                onClick={() => handleNavAway('mailto:hello@climatemind.org')}
+              >
+                Email Us
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Drawer>
+    </>
+  );
+};
+
+export default MenuDrawer;

--- a/src/components/AppBar/MenuDrawer.tsx
+++ b/src/components/AppBar/MenuDrawer.tsx
@@ -33,6 +33,14 @@ const useStyles = makeStyles((theme: Theme) =>
       border: "solid 1px", 
       height: 'calc(100vh - 80px)', 
     },
+    drawerListItem: {
+      cursor: 'pointer',
+      border: '1px solid grey',
+      '&:hover': {
+        backgroundColor: theme.palette.action.hover,
+      }
+    },
+    // MuiListItem-root
     menuEmail: {
       marginTop: '1em',
     },
@@ -144,6 +152,8 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
               <ListItem
                 component="li"
                 disableGutters={true}
+                className={classes.drawerListItem} 
+                // style={{cursor: 'pointer'}}
                 onClick={() => handleNav(ROUTES.ROUTE_PRIVACY)}
               >
                 <ListItemText primary="Privacy Policy" />


### PR DESCRIPTION
- The menu for desktops is now a drawer:

![image](https://user-images.githubusercontent.com/10048951/120933796-0dc4ed80-c6fc-11eb-840e-7095064cd86c.png)

Loggged in and with AppBarMenu:

![image](https://user-images.githubusercontent.com/10048951/120933853-554b7980-c6fc-11eb-9ef4-42989003c0b1.png)
 
- The menu items can be hovered with a poiner cursor and highlighted

- For desktops, the menu does not disappear when scrolling