### PR TITLE
pushed the hamburger menu to the far right of the navigation bar

### DIFF
--- a/src/components/AppBar/AppBarWithMenu.tsx
+++ b/src/components/AppBar/AppBarWithMenu.tsx
@@ -52,6 +52,9 @@ const useStyles = makeStyles((theme: Theme) =>
     rightCol: {
       paddingLeft: '24px',
     },
+    navbarLeftSide: {
+      display: 'flex', flexDirection:"row", justifyContent: 'center', alignItems: 'center', flex:1
+    },
   })
 );
 
@@ -123,14 +126,14 @@ const CmAppBarWithMenu: React.FC<AppBarWithMenuProps> = ({
           <Grid
             container
             direction="row"
-            justify="center"
+            justify="space-between"
             alignItems="center"
           >
+
+            <div className={classes.navbarLeftSide}>
             <Grid item>
               <AccountIcon />
             </Grid>
-
-            <Grid>
               <Tabs value={value} onChange={handleChange} centered>
                 {links.map((item) => (
                   <Tab
@@ -144,7 +147,8 @@ const CmAppBarWithMenu: React.FC<AppBarWithMenuProps> = ({
                   />
                 ))}
               </Tabs>
-            </Grid>
+            </div>
+
             <Grid className={classes.rightCol}>
               <IconButton
                 edge="start"


### PR DESCRIPTION
Here is the change I added.

## Screenshot here

Pushes the hamburger menu icon to the far right of the navigation bar.
<img width="1280" alt="Screen Shot 2021-06-19 at 7 58 28 PM" src="https://user-images.githubusercontent.com/22288040/122650058-6c955880-d139-11eb-8f18-73fac54efebc.png">

## Video demo

https://user-images.githubusercontent.com/22288040/122650201-3e644880-d13a-11eb-80a1-61f62e6e915b.mov


@johols 