### PR TITLE
CM-693: Prepare dummy intro page with button

### DIFF
--- a/cypress/integration/climatefeed.spec.ts
+++ b/cypress/integration/climatefeed.spec.ts
@@ -52,7 +52,7 @@ describe('Climate Feed loads and looks correct', () => {
     });
 
     // Click Conversations
-    cy.get('[data-testid="BottomMenu"]').contains('Conversations').click();
+    cy.get('[data-testid="BottomMenu"]').contains('Talk').click();
     cy.location().should((loc) => {
       expect(loc.pathname).to.eq('/conversations');
     });

--- a/src/__tests__/src/Conversations.test.tsx
+++ b/src/__tests__/src/Conversations.test.tsx
@@ -27,17 +27,13 @@ jest.mock('react-query', () => ({
 describe('Conversations page', () => {
   it('it has correct action text', () => {
     const { getByText } = render(<Conversations />);
-    expect(getByText(/Coming soon!/i)).toBeInTheDocument();
-    expect(
-      getByText(
-        /Want to be the first to use our revolutionary feature\? Or just want to stay in the loop for important updates\? Drop us your email below./i
-      )
-    ).toBeInTheDocument();
-    expect(getByText(/hello@climatemind.org/i)).toBeInTheDocument();
+    expect(getByText(/How to talk about Climate Change…/i)).toBeInTheDocument();
+    expect(getByText(/Talking about climate change is the most effective way to take action./i)).toBeInTheDocument();
+    expect(getByText(/Step 1: Bond/i)).toBeInTheDocument();
   });
 
-  it('it has the signup form', () => {
+  it('it has Start talking button', () => {
     const { getByTestId } = render(<Conversations />);
-    expect(getByTestId('MailChimpSignUp')).toBeInTheDocument();
+    expect(getByTestId('start-talking-with-people-button')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/src/__components__/BottomMenu.test.tsx
+++ b/src/__tests__/src/__components__/BottomMenu.test.tsx
@@ -61,7 +61,7 @@ describe('BottomMenu', () => {
     expect(getByText(/Feed/i)).toBeInTheDocument();
     expect(getByText(/Myths/i)).toBeInTheDocument();
     expect(getByText(/Actions/i)).toBeInTheDocument();
-    expect(getByText(/Conversations/i)).toBeInTheDocument();
+    expect(getByText(/Talk/i)).toBeInTheDocument();
   });
 
   it('Click on myths links changes route/page', () => {

--- a/src/components/AppBar/PageWithAppBottomBar.tsx
+++ b/src/components/AppBar/PageWithAppBottomBar.tsx
@@ -29,7 +29,7 @@ const PageWithAppBottomBar: React.FC<Props> = ({ component }) => {
       index: 3,
     },
     {
-      label: 'Conversations',
+      label: 'Talk',
       value: '/conversations',
       index: 4,
     },

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -42,7 +42,7 @@ export const bottomMenuLinks = [
     index: 3,
   },
   {
-    label: 'Conversations',
+    label: 'Talk',
     value: '/conversations',
     index: 4,
   },

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -8,11 +8,16 @@ import {
 import { makeStyles, createStyles } from '@material-ui/core/styles';
 import theme from '../common/styles/CMTheme';
 
-const PageTitle: React.FC<TypographyProps> = ({ children, variant = 'h1' }) => {
+
+interface PageTitleProps {
+  align?: string,
+}
+
+const PageTitle: React.FC<TypographyProps & PageTitleProps> = ({ children, variant = 'h1', align }) => {
   const useStyles = makeStyles((theme) =>
     createStyles({
       root: {
-        textAlign: 'center',
+        textAlign: align ? align : 'center',
         width: '100%',
       },
       heading: {

--- a/src/pages/Conversations.tsx
+++ b/src/pages/Conversations.tsx
@@ -5,12 +5,10 @@ import {
   Box,
   makeStyles,
   createStyles,
-  Link,
+  Button,
 } from '@material-ui/core';
 import Wrapper from '../components/Wrapper';
 import { COLORS } from '../common/styles/CMTheme';
-import EmailSignUpForm from '../components/EmailSubscribeForm';
-import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import PageContent from '../components/PageContent';
 import PageTitle from '../components/PageTitle';
 
@@ -39,6 +37,11 @@ const useStyles = makeStyles(() =>
         marginBottom: '1em',
       },
     },
+    bullet: {
+      "&::before": {
+        content: '"• "'
+      },
+    },
   })
 );
 
@@ -50,19 +53,8 @@ const ConversationsPage: React.FC = () => {
       <Wrapper bgColor={COLORS.ACCENT3} fullHeight={true}>
         <PageContent>
           <Box>
-            <Grid
-              container
-              direction="row"
-              justify="center"
-              alignItems="center"
-              spacing={0}
-            >
-              <Grid item>
-                <QuestionAnswerIcon className={classes.bigIcon} />
-              </Grid>
-              <Grid item>
-                <PageTitle>Coming soon!</PageTitle>
-              </Grid>
+            <Grid item>
+              <PageTitle>How to talk about Climate Change…</PageTitle>
             </Grid>
           </Box>
 
@@ -72,28 +64,67 @@ const ConversationsPage: React.FC = () => {
               action.
             </Typography>
           </Box>
-          <Box my={6}>
-            <Typography variant="body1" component="p" align="center">
-              Want to be the first to use our revolutionary feature? Or just
-              want to stay in the loop for important updates? Drop us your email
-              below.
-            </Typography>
-          </Box>
-          <EmailSignUpForm />
-          <Box mt={6} className={classes.links}>
-            <Typography variant="body1" component="p" align="center">
-              Check out{' '}
-              <Link href="http://www.climatemind.org">climatemind.org</Link> if
-              you are interested in helping out.
-            </Typography>
 
-            <Typography variant="body1" component="p" align="center">
-              Any questions or feedback? Drop us an email at{' '}
-              <Link href="mailto:hello@climatemind.org">
-                hello@climatemind.org
-              </Link>
+          <Box display="flex" justifyContent="flex-start">
+            <PageTitle align="left">Step 1: Bond</PageTitle>
+          </Box>
+          <Box display="flex" justifyContent="flex-start">
+            <Typography variant="h6" component="h6" align="left">
+              Start your conversation by bonding over similarities in personal 
+              values and interests.
             </Typography>
           </Box>
+          <Box display="flex" pt={1} justifyContent="flex-start">
+              <Typography variant="body1" component="p" className={classes.bullet} align="left">
+              Climate Mind helps with this by giving you a special link to the values questionnaire to share with others before you chat.
+              </Typography>
+          </Box>
+          <Box display="flex" justifyContent="flex-start">
+            <PageTitle align="left">Step 2: Connect</PageTitle>
+          </Box>
+          <Box display="flex" justifyContent="flex-start">
+            <Typography variant="h6" component="h6" align="left">
+              Connect the dots for others on how your shared values relate to climate change.
+            </Typography>
+          </Box>
+          <Box display="flex" pt={1} justifyContent="flex-start">
+            <Typography variant="body1" component="p" className={classes.bullet} align="left">
+              Climate Mind will find the connections so you don’t have to!
+            </Typography>
+          </Box>
+          <Box display="flex" justifyContent="flex-start">
+            <PageTitle align="left">Step 3: Inspire</PageTitle>
+          </Box>
+          <Box display="flex" justifyContent="flex-start">
+            <Typography variant="h6" component="h6" align="left">
+              Motivate the other person with solutions they find attractive.
+            </Typography>
+          </Box>
+          <Box display="flex" pt={1} justifyContent="flex-start">
+            <Typography variant="body1" component="p" className={classes.bullet} align="left">
+              Climate Mind has you covered for this one too!
+            </Typography>
+          </Box>
+          <Grid 
+            container
+            direction="row"
+            justify="center"
+            alignItems="center"
+            spacing={0}
+          >
+            <Box mt={8} mb={3}>
+              <Button
+                color="primary"
+                // onClick={() => push(ROUTES.ROUTE_SHARE_LINK)}
+                variant="contained"
+                disableElevation
+                data-testid="start-talking-with-people-button"
+              >
+                Start Talking With People
+              </Button>
+            </Box>
+          </Grid>
+          
         </PageContent>
       </Wrapper>
     </>


### PR DESCRIPTION
Conversations page matches design. Note that the route is still /conversations. In future we might consider changing it to /talk

![image](https://user-images.githubusercontent.com/10048951/122682852-1dfcc280-d1fc-11eb-8084-990e05fcb612.png)

and:

![image](https://user-images.githubusercontent.com/10048951/122682903-59978c80-d1fc-11eb-92fa-1a8912f89bbc.png)
