### PR TITLE
CM-800: White text and image overlaps above elements on home page

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,7 +17,8 @@ const styles = makeStyles(() => {
       backgroundColor: 'red',
     },
     section: {
-      minHeight: '50vh',
+      height: '50vh',
+      minHeight: '450px',
       display: 'grid',
       gridTemplateColumns: '1fr',
       gridTemplateRows: '1fr',
@@ -127,7 +128,7 @@ const Home: React.FC<{}> = () => {
       </section>
 
       <section className={`${classes.section} ${classes.bottomSection}`}>
-        <div className={classes.container}>
+        <div className={classes.container} >
           <Box mt={isXs ? -3 : -12}>
             <Typography align="center" className={classes.bottomText}>
               We’ll help connect the dots between you, a changing climate and

--- a/src/pages/StartQuiz.tsx
+++ b/src/pages/StartQuiz.tsx
@@ -16,7 +16,8 @@ const useStyles = makeStyles(() =>
       minHeight: '100vh',
     },
     section: {
-      minHeight: '50vh',
+      height: '50vh',
+      minHeight: '450px',
       display: 'grid',
       gridTemplateColumns: '1fr',
       gridTemplateRows: '1fr',


### PR DESCRIPTION
Ticket: https://climatemind.atlassian.net/jira/software/projects/CM/boards/1?selectedIssue=CM-800

Added height of 50vh and swapped min-height to absolute units to prevent component ever getting too small to hold content. 

Found bug in Home.tsx and StartQuiz.tsx so edited both files. 