### PR TITLE
CM-771_session_id_with_req_headers

### DIFF
--- a/src/api/getFeed.ts
+++ b/src/api/getFeed.ts
@@ -1,6 +1,5 @@
-import axio from 'axios';
 import { TClimateEffects } from '../types/types';
-import { getAppSetting } from '../getAppSetting';
+import { climateApi } from './apiHelper';
 
 export type Response = {
   climateEffects: TClimateEffects;
@@ -8,12 +7,11 @@ export type Response = {
 
 export const getFeed = async (quizId: string): Promise<Response> => {
   // Set up the call
-  const API_HOST = getAppSetting('REACT_APP_API_URL');
   const FEED_ENDPOINT = '/feed';
-  const REQUEST_URL = `${API_HOST}${FEED_ENDPOINT}?quizId=${quizId}`;
+  const REQUEST_URL = `${FEED_ENDPOINT}?quizId=${quizId}`;
   try {
     // Call the api
-    const response = await axio.get(REQUEST_URL);
+    const response = await climateApi.get(REQUEST_URL);
     const data = response.data;
     return data;
   } catch (err) {

--- a/src/api/getMyths.ts
+++ b/src/api/getMyths.ts
@@ -1,17 +1,14 @@
-import axios from 'axios';
-import { buildUrl } from './apiHelper';
 import { TMyths } from '../types/Myths';
+import { climateApi } from '../api/apiHelper';
 
 type Response = {
   myths: TMyths;
 };
 
 export async function getMyths(): Promise<Response> {
-  const REQUEST_URL = buildUrl('/myths');
-
   // Try and make the request
   try {
-    const response = await axios.get(REQUEST_URL);
+    const response = await climateApi.get('/myths');
     const data = response.data;
     return data;
   } catch (err) {

--- a/src/api/getOneMyth.ts
+++ b/src/api/getOneMyth.ts
@@ -1,19 +1,17 @@
-import axios from 'axios';
 import { TMyth } from '../types/Myths';
-import { getAppSetting } from '../getAppSetting';
+import { climateApi } from './apiHelper';
 
 type Response = {
   myth: TMyth;
 };
 
 export async function getOneMyth(iri: string): Promise<Response> {
-  const API_HOST = getAppSetting('REACT_APP_API_URL');
   const MYTHS_ENDPOINT = '/myths';
-  const REQUEST_URL = `${API_HOST}${MYTHS_ENDPOINT}/${iri}`;
+  const REQUEST_URL = `${MYTHS_ENDPOINT}/${iri}`;
 
   // Try and make the request
   try {
-    const response = await axios.get(REQUEST_URL);
+    const response = await climateApi.get(REQUEST_URL);
     const data = response.data;
     return data;
   } catch (err) {

--- a/src/api/getPersonalValues.ts
+++ b/src/api/getPersonalValues.ts
@@ -1,18 +1,16 @@
-import axios from 'axios';
 import { TPersonalValues } from '../types/types';
 import { TError } from '../types/Error';
-import { getAppSetting } from '../getAppSetting';
+import { climateApi } from './apiHelper';
 
 const getPersonalValues = async (
   quizId: string
 ): Promise<TPersonalValues | TError> => {
   // Set up the call
-  const API_HOST = getAppSetting('REACT_APP_API_URL');
   const PERSONAL_VALUES_ENDPOINT = '/personal_values';
-  const REQUEST_URL = `${API_HOST}${PERSONAL_VALUES_ENDPOINT}?quizId=${quizId}`;
+  const REQUEST_URL = `${PERSONAL_VALUES_ENDPOINT}?quizId=${quizId}`;
   try {
     // Call the api
-    const response = await axios.get(REQUEST_URL);
+    const response = await climateApi.get(REQUEST_URL);
     const data = response.data;
     return data;
     // Return the response object

--- a/src/api/getSolutions.ts
+++ b/src/api/getSolutions.ts
@@ -1,18 +1,17 @@
-import axios from 'axios';
-import { buildUrl } from './apiHelper';
 import { TSolutions } from '../types/Solutions';
+import { climateApi } from './apiHelper';
 
 type Response = {
   solutions: TSolutions;
 };
 
 export async function getSolutions(quizId: string): Promise<Response> {
-  const REQUEST_URL = buildUrl('/solutions');
+  const REQUEST_URL = '/solutions';
   const REQUEST_URL_WITH_QUIZID = `${REQUEST_URL}?quizId=${quizId}`;
 
   // Try and make the request
   try {
-    const response = await axios.get(REQUEST_URL_WITH_QUIZID);
+    const response = await climateApi.get(REQUEST_URL_WITH_QUIZID);
     const data = response.data;
     return data;
   } catch (err) {

--- a/src/api/postLogin.ts
+++ b/src/api/postLogin.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
-import { buildUrl } from './apiHelper';
 import { TUser } from '../types/User';
+import { climateApi } from '../api/apiHelper';
 
 export type loginPayload = {
   email: string;
@@ -17,10 +16,10 @@ export const postLogin = async ({
   email,
   password,
 }: loginPayload): Promise<loginResponse> => {
-  const url = buildUrl('/login');
+  const url = '/login';
   try {
     // Make request for token
-    const request = await axios.post(
+    const request = await climateApi.post(
       url,
       {
         email,

--- a/src/api/postLogout.ts
+++ b/src/api/postLogout.ts
@@ -5,7 +5,6 @@ interface Response {
 }
 
 export const postLogout = async (): Promise<Response> => {
-  // const url = buildUrl('/logout');
   try {
     // Make request for token
     const request = await climateApi.post(

--- a/src/api/postRefresh.ts
+++ b/src/api/postRefresh.ts
@@ -8,8 +8,6 @@ export type refreshResponse = {
 };
 
 export const postRefresh = async (): Promise<refreshResponse> => {
-  // const REQUEST_URL = buildUrl('/refresh');
-
   try {
     // Call the api
     const response = await climateApi('/refresh', {

--- a/src/api/postRegister.ts
+++ b/src/api/postRegister.ts
@@ -1,5 +1,4 @@
-import axios from 'axios';
-import { buildUrl } from './apiHelper';
+import { climateApi } from './apiHelper';
 
 export type registrationPayload = {
   firstName: string;
@@ -27,11 +26,11 @@ export const postRegister = async ({
   password,
   email,
 }: registrationPayload): Promise<registrationResponse> => {
-  const url = buildUrl('/register');
+  const url = '/register';
 
   try {
     // Make request for token
-    const request = await axios({
+    const request = await climateApi({
       method: 'post',
       url,
       data: {

--- a/src/api/postScores.ts
+++ b/src/api/postScores.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
 import { TResponse } from '../types/types';
-import { buildUrl } from './apiHelper';
+import { climateApi } from './apiHelper';
 
 type TScoreSubmitResponse = {
   quizId: string;
@@ -25,14 +24,11 @@ export async function submitScores(
 
   // Auth token added for logged in user so that the session id can be assigned to the user
   const HEADERS = { Authorization: jwt ? `Brearer ${jwt}` : '' };
-
-  // Build the correct url
-  const SCORE_ENDPOINT = '/scores';
-  const REQUEST_URL = buildUrl(SCORE_ENDPOINT);
+  const REQUEST_URL = '/scores';
 
   // Try and make the request
   try {
-    const response = await axios.post(REQUEST_URL, REQUEST_BODY, {
+    const response = await climateApi.post(REQUEST_URL, REQUEST_BODY, {
       headers: HEADERS,
     });
     const data = await response.data;

--- a/src/api/postSubscriber.ts
+++ b/src/api/postSubscriber.ts
@@ -1,5 +1,4 @@
-import axios from 'axios';
-import { buildUrl } from './apiHelper';
+import { climateApi } from './apiHelper';
 
 interface Response {
   datetime: string;
@@ -21,12 +20,11 @@ export async function postSubscriber(data: payload): Promise<Response> {
   };
 
   // Build the correct url
-  const SCORE_ENDPOINT = '/subscribe';
-  const REQUEST_URL = buildUrl(SCORE_ENDPOINT);
+  const REQUEST_URL = '/subscribe';
 
   // Try and make the request
   try {
-    const response = await axios.post(REQUEST_URL, REQUEST_BODY);
+    const response = await climateApi.post(REQUEST_URL, REQUEST_BODY);
     const data = response.data;
     return data;
   } catch (err) {

--- a/src/api/postZipcode.ts
+++ b/src/api/postZipcode.ts
@@ -1,5 +1,4 @@
-import axios from 'axios';
-import { buildUrl } from './apiHelper';
+import { climateApi } from './apiHelper';
 
 interface Response {
   message: string;
@@ -20,12 +19,11 @@ export async function postZipcode(data: payload): Promise<Response> {
   };
 
   // Build the correct url
-  const ZIPCODE_ENDPOINT = '/post-code';
-  const REQUEST_URL = buildUrl(ZIPCODE_ENDPOINT);
+  const REQUEST_URL = '/post-code';
 
   // Try and make the request
   try {
-    const response = await axios.post(REQUEST_URL, REQUEST_BODY);
+    const response = await climateApi.post(REQUEST_URL, REQUEST_BODY);
     const data = response.data;
     return data;
   } catch (err) {

--- a/src/hooks/useClimateApi.ts
+++ b/src/hooks/useClimateApi.ts
@@ -1,0 +1,33 @@
+import { getAppSetting } from '../getAppSetting';
+import axios from 'axios';
+import { useSession } from './useSession';
+
+const API_HOST = getAppSetting('REACT_APP_API_URL');
+
+const IN_DEV = process.env.NODE_ENV === 'development';
+
+export const useClimateApi = () => {
+  const { sessionId } = useSession();
+  const climateApi = axios.create({
+    baseURL: API_HOST,
+    headers: { 'X-Session-Id': sessionId },
+  });
+
+  // Intercept and log out request config in dev
+  climateApi.interceptors.request.use((config) => {
+    if (IN_DEV) {
+      console.log(config);
+    }
+    return config;
+  });
+
+  // Intercept and log out responses in dev
+  climateApi.interceptors.response.use((config) => {
+    if (IN_DEV) {
+      console.log(config);
+    }
+    return config;
+  });
+
+  return climateApi;
+};

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -1,5 +1,6 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { SessionContext, SessionDispatch } from '../contexts/session';
+import { climateApi } from '../api/apiHelper';
 
 // TODO: Quiz Session needs update to the new thing
 export const useSession = () => {
@@ -13,6 +14,16 @@ export const useSession = () => {
     setHasAcceptedCookies,
     quizId,
   } = session;
+
+  // add session id to all api requests as a custom header
+  useEffect(() => {
+    sessionId &&
+      climateApi.interceptors.request.use((config) => {
+        config.headers['X-Session-Id'] = sessionId;
+
+        return config;
+      });
+  }, [sessionId]);
 
   // We dont want to clear has acceptedPrivacyPolicy
   const clearSession = () => {


### PR DESCRIPTION
Add X-Session-Id header containing the session ID to all requests after a session id is obtained.

- Set up an axios instance called climate api
- Change all api call to use new instance
- Used interceptor to add X-Session-Id custom header to all api calls once a sesion id is obtained. 

There is a demo [here](https://www.loom.com/share/7f5032d1c6c6490793b244bc3133fbd0)