### PR TITLE
 CM-807_Keep_session_id_after_refresh

### DIFF
--- a/cypress/integration/invitedUser.spec.ts
+++ b/cypress/integration/invitedUser.spec.ts
@@ -6,7 +6,7 @@ describe('Invited User Journey', () => {
     cy.mockServer();
   });
 
-  it.only('allows link to be shared', () => {
+  it('allows link to be shared', () => {
     cy.login();
     cy.wait(1).contains(/talk/i).click();
     cy.contains(/start talking with people/i).click();

--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -5,9 +5,6 @@ import { terminalLog } from '../support/helpers';
 describe('Personal values page loads and looks correct', () => {
   beforeEach(() => {
     cy.acceptCookies();
-    cy.setSession();
-    const sessionId = '1234';
-
     cy.mockServer();
 
     cy.visit('./questionnaire');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -85,10 +85,6 @@ Cypress.Commands.add('acceptCookies', () => {
   window.localStorage.setItem('hasAcceptedCookies', 'true');
 });
 
-Cypress.Commands.add('setSession', () => {
-  window.localStorage.setItem('sessionId', '1234');
-});
-
 Cypress.Commands.add('login', () => {
   cy.acceptCookies();
   cy.visit('/login');

--- a/src/contexts/queryClient.tsx
+++ b/src/contexts/queryClient.tsx
@@ -16,7 +16,6 @@ export const QueryProvider: React.FC = ({ children }) => {
   });
 
   const { sessionId } = useSession();
-  console.log({ sessionId });
 
   useEffect(() => {
     // Prefetch myths

--- a/src/contexts/session.tsx
+++ b/src/contexts/session.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useEffect } from 'react';
 import { TSession } from '../types/Session';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useGetSessionId } from '../hooks/useGetSessionId';
 
 export type TSessionDispatch = React.Dispatch<React.SetStateAction<TSession>>;
 
@@ -13,6 +14,9 @@ export const SessionProvider: React.FC = ({ children }) => {
     'hasAcceptedCookies',
     false
   );
+
+  // gets a unique session id on load for the session and stores in session storage
+  const fetchedSessionId = useGetSessionId();
 
   const [session, setSession] = useState<TSession>({
     sessionId: null,
@@ -29,6 +33,16 @@ export const SessionProvider: React.FC = ({ children }) => {
       hasAcceptedCookies,
     }));
   }, [hasAcceptedCookies]);
+
+  useEffect(() => {
+    setSession((prevState) => {
+      console.log('fetched', { fetchedSessionId });
+      return {
+        ...prevState,
+        sessionId: fetchedSessionId ? fetchedSessionId : null,
+      };
+    });
+  }, [fetchedSessionId]);
 
   return (
     <SessionContext.Provider value={session}>

--- a/src/contexts/session.tsx
+++ b/src/contexts/session.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useState, useEffect } from 'react';
 import { TSession } from '../types/Session';
 import { useLocalStorage } from '../hooks/useLocalStorage';
-import { postSession } from '../api/postSession';
 
 export type TSessionDispatch = React.Dispatch<React.SetStateAction<TSession>>;
 
@@ -30,24 +29,6 @@ export const SessionProvider: React.FC = ({ children }) => {
       hasAcceptedCookies,
     }));
   }, [hasAcceptedCookies]);
-
-  // Set session id on load
-  useEffect(() => {
-    async function getSessionId() {
-      try {
-        const data = await postSession();
-        const newSessionId = data.sessionId;
-        setSession((prevSession) => ({
-          ...prevSession,
-          sessionId: newSessionId,
-        }));
-      } catch (err) {
-        console.error(err);
-      }
-    }
-
-    getSessionId();
-  }, []);
 
   return (
     <SessionContext.Provider value={session}>

--- a/src/contexts/session.tsx
+++ b/src/contexts/session.tsx
@@ -35,14 +35,12 @@ export const SessionProvider: React.FC = ({ children }) => {
   }, [hasAcceptedCookies]);
 
   useEffect(() => {
-    setSession((prevState) => {
-      console.log('fetched', { fetchedSessionId });
-      return {
-        ...prevState,
-        sessionId: fetchedSessionId ? fetchedSessionId : null,
-      };
-    });
-  }, [fetchedSessionId]);
+    setSession((prevState) => ({
+      ...prevState,
+      sessionId: fetchedSessionId ? fetchedSessionId : null,
+    }));
+    // Added the session.sessionId to the dep array as it is being updated to null elsewhere.
+  }, [fetchedSessionId, session.sessionId]);
 
   return (
     <SessionContext.Provider value={session}>

--- a/src/hooks/auth/useAuth.tsx
+++ b/src/hooks/auth/useAuth.tsx
@@ -2,13 +2,13 @@ import { useContext, useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useHistory } from 'react-router';
 import { loginResponse, postLogin } from '../../api/postLogin';
-import { refreshResponse } from '../../api/postRefresh';
 import { postLogout } from '../../api/postLogout';
+import { refreshResponse } from '../../api/postRefresh';
 import ROUTES from '../../components/Router/RouteConfig';
 import { AuthContext, AuthDispatch, emptyUser } from '../../contexts/auth';
+import { TAuth } from '../../types/Auth';
 import { useSession } from '../useSession';
 import { useToast } from '../useToast';
-import { TAuth } from '../../types/Auth';
 import { useRefresh } from './useRefresh';
 
 interface userLogin {
@@ -81,7 +81,7 @@ export function useAuth() {
           quizId: response.user.quiz_id,
         };
         setUserContext(user);
-        // TODO: Set the session id for the logged in user
+
         if (response.user.quiz_id) {
           setQuizId(response.user.quiz_id);
         } else {

--- a/src/hooks/useGetSessionId.ts
+++ b/src/hooks/useGetSessionId.ts
@@ -1,0 +1,23 @@
+import { useEffect, useCallback } from 'react';
+import { useSessionStorage } from './useSessionStorage';
+import { postSession } from '../api/postSession';
+
+export function useGetSessionId() {
+  const { data, storeValue } = useSessionStorage('', 'sessionId');
+
+  const getSessionId = useCallback(async () => {
+    try {
+      const data = await postSession();
+      const newSessionId = data.sessionId;
+      storeValue(newSessionId);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [storeValue]);
+
+  useEffect(() => {
+    data === '' && getSessionId();
+  }, [data, getSessionId]);
+
+  return data;
+}

--- a/src/hooks/useGetSessionId.ts
+++ b/src/hooks/useGetSessionId.ts
@@ -1,9 +1,10 @@
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useSessionStorage } from './useSessionStorage';
 import { postSession } from '../api/postSession';
 
 export function useGetSessionId() {
   const { data, storeValue } = useSessionStorage('', 'sessionId');
+  const [hasFetchedSessionId, setHasFetchedSessionId] = useState(false);
 
   const getSessionId = useCallback(async () => {
     try {
@@ -16,8 +17,11 @@ export function useGetSessionId() {
   }, [storeValue]);
 
   useEffect(() => {
-    data === '' && getSessionId();
-  }, [data, getSessionId]);
+    if (data === '' && !hasFetchedSessionId) {
+      getSessionId();
+      setHasFetchedSessionId(true);
+    }
+  }, [data, getSessionId, hasFetchedSessionId]);
 
   return data;
 }

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -1,15 +1,11 @@
 import { useContext, useEffect, useCallback } from 'react';
 import { SessionContext, SessionDispatch } from '../contexts/session';
 import { climateApi } from '../api/apiHelper';
-import { useGetSessionId } from '../hooks/useGetSessionId';
 
 // TODO: Quiz Session needs update to the new thing
 export const useSession = () => {
   const session = useContext(SessionContext);
   const setSession = useContext(SessionDispatch);
-
-  // gets a unique session id on load for the session and stores in session storage
-  const initSessionId = useGetSessionId();
 
   const {
     sessionId,
@@ -60,10 +56,11 @@ export const useSession = () => {
     }
   };
 
-  // intialise session-id
-  useEffect(() => {
-    initSessionId && setSessionId(initSessionId);
-  }, [initSessionId, setSessionId]);
+  // TODO: Tidy UP
+  // // intialise session-id
+  // useEffect(() => {
+  //   initSessionId && setSessionId(initSessionId);
+  // }, [initSessionId, setSessionId]);
 
   // add session id to all api requests as a custom header
   useEffect(() => {

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -1,11 +1,15 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useCallback } from 'react';
 import { SessionContext, SessionDispatch } from '../contexts/session';
 import { climateApi } from '../api/apiHelper';
+import { useGetSessionId } from '../hooks/useGetSessionId';
 
 // TODO: Quiz Session needs update to the new thing
 export const useSession = () => {
   const session = useContext(SessionContext);
   const setSession = useContext(SessionDispatch);
+
+  // gets a unique session id on load for the session and stores in session storage
+  const initSessionId = useGetSessionId();
 
   const {
     sessionId,
@@ -15,36 +19,28 @@ export const useSession = () => {
     quizId,
   } = session;
 
-  // add session id to all api requests as a custom header
-  useEffect(() => {
-    sessionId &&
-      climateApi.interceptors.request.use((config) => {
-        config.headers['X-Session-Id'] = sessionId;
-
-        return config;
-      });
-  }, [sessionId]);
-
-  // We dont want to clear has acceptedPrivacyPolicy
+  // We dont want to clear has acceptedPrivacyPolicy or the session Id then retaiking the quiz
   const clearSession = () => {
     if (setSession) {
-      setSession({
-        ...session,
-        sessionId: null,
+      setSession((prevSession) => ({
+        ...prevSession,
         zipCode: null,
         quizId: null,
-      });
+      }));
     }
   };
 
-  const setSessionId = (sessionId: string) => {
-    if (setSession) {
-      setSession({
-        ...session,
-        sessionId: sessionId,
-      });
-    }
-  };
+  const setSessionId = useCallback(
+    (sessionId: string) => {
+      if (setSession) {
+        setSession((prevSession) => ({
+          ...prevSession,
+          sessionId: sessionId,
+        }));
+      }
+    },
+    [setSession]
+  );
 
   const setZipCode = (zipCode: string) => {
     if (setSession) {
@@ -63,6 +59,21 @@ export const useSession = () => {
       });
     }
   };
+
+  // intialise session-id
+  useEffect(() => {
+    initSessionId && setSessionId(initSessionId);
+  }, [initSessionId, setSessionId]);
+
+  // add session id to all api requests as a custom header
+  useEffect(() => {
+    sessionId &&
+      climateApi.interceptors.request.use((config) => {
+        config.headers['X-Session-Id'] = sessionId;
+
+        return config;
+      });
+  }, [sessionId]);
 
   return {
     sessionId,

--- a/src/hooks/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+export function useSessionStorage(initialData: string, key: string) {
+  const [data, setData] = useState<string | undefined>(undefined);
+
+  // Check if there is already a value is session store or set to initial data
+  useEffect(() => {
+    const storedData = sessionStorage.getItem(key);
+    storedData ? setData(storedData) : setData(initialData);
+  }, [initialData, key]);
+
+  // Set data to session store each time it changes
+  useEffect(() => {
+    data && sessionStorage.setItem(key, data);
+  }, [data, key]);
+
+  const storeValue = (data: string) => {
+    setData(data);
+  };
+
+  return { data, storeValue };
+}


### PR DESCRIPTION
We want to assign a session id on load of the app which can be persisted through out the whole of the session across browser re-freshes. To acheive this i used session storage which works like local storage but is specific to a browser tab and clears when the tab is closed. 



- Created a hook to use session storage
- Created a hook to get a session id once and store in session stoage
- Update useSession hook to set the session id on the browser 

There is [Demo Here](https://www.loom.com/share/ef656f5a1c9a4fdaa9b5d1b3e8f7021d)

**NOTE: If you have more than one browser tab open each tab will count as a separate session**

**NOTE: Looks like all our cypress tests were not previously running as .only mistakenly committed to the repo.**
