### PR TITLE
CM-831 Personal values button only after quiz

### DIFF
--- a/cypress/integration/menubar.spec.ts
+++ b/cypress/integration/menubar.spec.ts
@@ -3,12 +3,33 @@
 import { terminalLog } from '../support/helpers.ts';
 
 describe('Menu bar opens and looks correct', () => {
-  it('can open menubar', () => {
+  beforeEach(() => {
     cy.acceptCookies();
+    cy.mockServer();
+  });
+
+  it('can open menubar', () => {
     cy.visit('/start');
     cy.get('[aria-label="menu"]').should('be.visible').click();
     cy.contains('About ClimateMind').should('be.visible');
     cy.checkAccessibility(terminalLog);
     cy.percySnapshot('MenuBar');
+  });
+
+  it('should have the right menu items', () => {
+    cy.login();
+    cy.get('[aria-label="menu"]').should('be.visible').click();
+    cy.contains(/About ClimateMind/i);
+    cy.contains(/Scientists Speak Up/i);
+    cy.contains(/Privacy Policy/i);
+    cy.contains(/LOG OUT/i);
+    cy.contains(/EMAIL US/i);
+  });
+
+  it('personal values and retake quiz should not be in the menu until user has take the quiz', () => {
+    cy.visit('/');
+    cy.get('[aria-label="menu"]').should('be.visible').click();
+    cy.contains(/Personal Values/i).should('not.exist');
+    cy.contains(/Re-take the Quiz/i).should('not.exist');
   });
 });

--- a/src/components/AppBar/MenuDrawer.tsx
+++ b/src/components/AppBar/MenuDrawer.tsx
@@ -60,7 +60,7 @@ const menuLinks = [
 const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
   const classes = useStyles();
   const { push } = useHistory();
-  const { sessionId, clearSession } = useSession();
+  const { quizId, clearSession } = useSession();
   const { setCurrentSet } = useQuestions();
   const { dispatch } = useResponses();
   const { clearPersonality } = useClimatePersonality();
@@ -113,7 +113,7 @@ const MenuDrawer: React.FC<MenuDrawerProps> = ({ isShowing, setIsShowing }) => {
           <Grid item>
             <List>
               {/* Personal Values option should only show if there is a session id */}
-              {sessionId && (
+              {quizId && (
                 <>
                   <ListItem
                     component="li"

--- a/src/components/AppBar/MenuPaper.tsx
+++ b/src/components/AppBar/MenuPaper.tsx
@@ -48,7 +48,7 @@ const menuLinks = [
 const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
   const classes = useStyles();
   const { push } = useHistory();
-  const { sessionId, clearSession } = useSession();
+  const { quizId, clearSession } = useSession();
   const { dispatch } = useResponses();
   const { clearPersonality } = useClimatePersonality();
   const { setCurrentSet } = useQuestions();
@@ -111,7 +111,7 @@ const TopMenu: React.FC<MenuPaperProps> = ({ isShowing, setIsShowing }) => {
             <Grid item>
               <List>
                 {/* Personal Values option should only show if there is a session id */}
-                {sessionId && (
+                {quizId && (
                   <>
                     <ListItem
                       component="li"


### PR DESCRIPTION
The menu options for personal values and and retake the quiz should only show when the user has re-taken the quiz. 

It was using session id instead of quiz id - oversight from a previous story. 

Improved cypress tests to check for the correct menu options