### PR TITLE
Add front end logging using LogRocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17730,6 +17730,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
+    "logrocket": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-2.0.0.tgz",
+      "integrity": "sha512-O+YdrtpQn7oOmrxCqOyUcaB1+ONrhyJuB9CX57PQ0JJzNrYstxd0Oyg6UdLisA7UjNmwTr6fixMO3WOysDTFFA=="
+    },
     "logrocket-react": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/logrocket-react/-/logrocket-react-4.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17730,6 +17730,11 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
+    "logrocket-react": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/logrocket-react/-/logrocket-react-4.0.1.tgz",
+      "integrity": "sha512-TbQELEaDQspKHH0XylAeVZpsHoAcz+sIEG/enUQiH+LoYLW7cMK000XIS6W3Zz14zS0V2Db+KyKi8ivBpGYkzg=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "formik": "^2.2.6",
     "lodash": "^4.17.21",
     "lodash.merge": "^4.6.2",
+    "logrocket-react": "^4.0.1",
     "moment": "^2.29.1",
     "react": "^16.13.1",
     "react-chartjs-2": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "formik": "^2.2.6",
     "lodash": "^4.17.21",
     "lodash.merge": "^4.6.2",
+    "logrocket": "^2.0.0",
     "logrocket-react": "^4.0.1",
     "moment": "^2.29.1",
     "react": "^16.13.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,9 +10,16 @@ import { ResponsesProvider } from './contexts/responses';
 import { SessionProvider } from './contexts/session';
 import AuthProvider from './contexts/auth';
 import { getAppSetting } from './getAppSetting';
+import LogRocket from 'logrocket';
 
 // .env.development Allows you to hide devtools
 const showRQTools = getAppSetting('REACT_APP_SHOW_RQ_TOOLS');
+const IN_DEV = process.env.NODE_ENV === 'development';
+
+// Don't run in development environment as the free plan only supports limited sessions
+if (!IN_DEV) {
+  LogRocket.init('4e1gkx/climatemind');
+}
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,6 @@ const LOGROCKET_PROJECTID = '4e1gkx/climatemind';
 if (!IN_DEV) {
   LogRocket.init(LOGROCKET_PROJECTID);
 }
-å;
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,11 +15,13 @@ import LogRocket from 'logrocket';
 // .env.development Allows you to hide devtools
 const showRQTools = getAppSetting('REACT_APP_SHOW_RQ_TOOLS');
 const IN_DEV = process.env.NODE_ENV === 'development';
+const LOGROCKET_PROJECTID = '4e1gkx/climatemind';
 
 // Don't run in development environment as the free plan only supports limited sessions
 if (!IN_DEV) {
-  LogRocket.init('4e1gkx/climatemind');
+  LogRocket.init(LOGROCKET_PROJECTID);
 }
+å;
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
Install LogRocket for front end monitoring and session replay.

I've set to only run in non dev enviromnents as the free plan is limited to 1000 sessions per month.  We can always swap out for something with higher limits at a later date but the effor to get it up and running is so low, it makes sense for just now. 

There's a nice session recording feature where it records DOM events and allows you to replay the session as a video.

I've send you an invite to joing the team.