### PR TITLE
Fix overflowing text on homepage

### DIFF
--- a/src/pages/EmailNewsletterSignUp.tsx
+++ b/src/pages/EmailNewsletterSignUp.tsx
@@ -83,20 +83,6 @@ export const EmailNewsletterSignUpPage: React.FC = () => {
               Any questions or feedback? Drop us an email at {''}
               <a
                 className={classes.links}
-                href="https://climatemind.org/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                climatemind.org
-              </a>
-            </Typography>
-          </Box>
-
-          <Box my={2}>
-            <Typography variant="body1" component="h6" align="center">
-              Any questions or feedback? Drop us an email at {''}
-              <a
-                className={classes.links}
                 href="mailto:hello@climatemind.org"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,8 +17,7 @@ const styles = makeStyles(() => {
       backgroundColor: 'red',
     },
     section: {
-      height: '50vh',
-      minHeight: '450px',
+      minHeight: '50vh',
       display: 'grid',
       gridTemplateColumns: '1fr',
       gridTemplateRows: '1fr',


### PR DESCRIPTION
This ticket fixes a couple of minor display issues, merging into Master to release. Will then merge master back into develop

## Fix overflowing text on homepage.

there was an absolute height set on the section which was causing the text to overflow

### Before 
<img width="434" alt="Screenshot 2022-02-14 at 17 00 34" src="https://user-images.githubusercontent.com/44759513/153912075-ec360b6a-959a-4def-a1d9-ce1042db6aaa.png">


### After 
<img width="418" alt="Screenshot 2022-02-14 at 17 01 05" src="https://user-images.githubusercontent.com/44759513/153912109-54412c0b-eb83-473a-9a8f-659259e422e7.png">


## Remove duplicate text on sign up form.

### Before
![Image from iOS](https://user-images.githubusercontent.com/44759513/153911948-43737ca9-8b5e-4196-9e95-0b0df84dd37a.png)


### After

<img width="410" alt="Screenshot 2022-02-14 at 17 07 16" src="https://user-images.githubusercontent.com/44759513/153911932-4965f7ce-9897-45df-a26b-bed4034f9a41.png">

