### PR TITLE
Remove_percy_snapshot

### DIFF
--- a/cypress/integration/personalvalues.spec.ts
+++ b/cypress/integration/personalvalues.spec.ts
@@ -35,7 +35,7 @@ describe('Personal values page loads and looks correct', () => {
   });
   it('navigate to the climate feed', () => {
     cy.get('[data-testid="CMCard-Image"]').invoke('attr', 'style', '');
-    cy.percySnapshot('Personal Values');
+    // cy.percySnapshot('Personal Values');
     cy.contains('Ready to dive into Climate Mind?').should('be.visible');
     cy.contains('Yes, I’m ready!').should('be.visible').click();
     cy.url().should('include', '/set-location');


### PR DESCRIPTION
Percy snapshot on personal values page is always different due to the animating notification / toast. There are also an number of other animated items on this screen which will make the screen shots always differ. 

I've done a bit of investigation into excluding certain areas of the page from percy, which seems to be possible but wasn't able to get it to work in the time i have.

For just now removing the offending snapshot is the quickest option.