### PR TITLE
Pressing enter shouldn't open the reset password form

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -163,6 +163,7 @@ const LoginPage: React.FC = () => {
               <Typography variant="body1" align="center">
                 Forgot your password? &emsp;{' '}
                 <button
+                  type="button"
                   onClick={() => setIsPwdResetModal(true)}
                   className={classes.resetPwdLink}
                 >


### PR DESCRIPTION
There's not yet a ticket for this, just a small issue I noticed after implementing [CM-566: User can reset his forgotten password (Part 1)](https://github.com/ClimateMind/climatemind-frontend/pull/319).
The video below is pretty short, but I just pressed enter while in the text field to enter my email / password. This opened the form to request a reset password link, which shouldn't happen.

https://user-images.githubusercontent.com/78958483/185806697-34d5ed8a-d908-40bb-b146-910adac27e4c.mp4