### PR TITLE
Fix 'No thanks' buttons route

### DIFF
--- a/src/pages/userB/HowCMWorks.tsx
+++ b/src/pages/userB/HowCMWorks.tsx
@@ -60,7 +60,10 @@ const HowCMWorks: React.FC = () => {
   };
 
   const handleNoThanks = () => {
-    push(ROUTES_CONFIG.USERB_NO_CONSENT, state);
+    push(ROUTES_CONFIG.USERB_NO_CONSENT, {
+      ...state,
+      prevLocation: `${ROUTES_CONFIG.ROUTE_HOW_CM_WORKS}`,
+    });
   };
 
   const handleNavAway = (url: string) => {

--- a/src/pages/userB/ShareSummary/ShareSummary.tsx
+++ b/src/pages/userB/ShareSummary/ShareSummary.tsx
@@ -124,6 +124,7 @@ const ShareSummary: React.FC = () => {
   const handleNotWow = () => {
     push(ROUTES_CONFIG.USERB_NO_CONSENT, {
       userAName: summary.userAName,
+      prevLocation: `${ROUTES_CONFIG.USERB_SHARED_IMPACTS}`,
     });
   };
 

--- a/src/pages/userB/UserBNoConsent/NoConsent.test.tsx
+++ b/src/pages/userB/UserBNoConsent/NoConsent.test.tsx
@@ -3,7 +3,6 @@ import { screen, render } from '@testing-library/react';
 import { NoConsent } from './UserBNoConsent';
 import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
-import ROUTES from '../../../components/Router/RouteConfig';
 
 const mockPush = jest.fn();
 
@@ -45,6 +44,5 @@ describe('<NoConsent Page', () => {
     userEvent.click(button);
 
     expect(button).toBeInTheDocument();
-    expect(mockPush).toBeCalledWith(ROUTES.USERB_SHARED_IMPACTS);
   });
 });

--- a/src/pages/userB/UserBNoConsent/UserBNoConsent.tsx
+++ b/src/pages/userB/UserBNoConsent/UserBNoConsent.tsx
@@ -5,7 +5,6 @@ import { Button } from '../../../components/Button';
 import PageContent from '../../../components/PageContent';
 import PageTitle from '../../../components/PageTitle';
 import PageWrapper from '../../../components/PageWrapper';
-import ROUTES from '../../../components/Router/RouteConfig';
 
 const styles = makeStyles((theme) => {
   return {
@@ -19,7 +18,7 @@ const styles = makeStyles((theme) => {
 export const NoConsent: React.FC<{}> = () => {
   const classes = styles();
   const { push } = useHistory();
-  const { state } = useLocation<{ userAName: string }>();
+  const { state } = useLocation<{ userAName: string; prevLocation: string }>();
 
   return (
     <PageWrapper>
@@ -55,7 +54,7 @@ export const NoConsent: React.FC<{}> = () => {
               variant="contained"
               color="primary"
               disableElevation
-              onClick={() => push(ROUTES.USERB_SHARED_IMPACTS)}
+              onClick={() => push(state.prevLocation)}
             >
               Back
             </Button>


### PR DESCRIPTION
While the route for the 'Not now' button later on in the userB story lead back to the '/shared-impacts' page, the first 'No thanks' did as well, although it should lead back to '/how-cm-works'. This is now fixed.