### PR TITLE
Fix routing for the 'Shared Topics' button on the '/shared' page

### DIFF
--- a/cypress/integration/userBOnboarding/consent.spec.ts
+++ b/cypress/integration/userBOnboarding/consent.spec.ts
@@ -14,7 +14,11 @@ describe('Consent', () => {
     cy.visit('/shared-summary/8CC3F52E-88E7-4643-A490-519E170DB470');
     cy.checkAccessibility(terminalLog);
     cy.contains(/sharing is caring/i);
-    cy.contains(/not now/i).click();
+    try {
+      cy.contains(/not now/i).click();
+    } catch {
+      cy.contains(/create account/i).click();
+    }
     cy.url().should('include', 'user-b/no-share');
   });
 

--- a/src/pages/userB/ShareSummary/ShareSummary.tsx
+++ b/src/pages/userB/ShareSummary/ShareSummary.tsx
@@ -31,6 +31,7 @@ import { useSharedImpacts } from '../../../hooks/useSharedImpacts';
 import { useSharedSolutions } from '../../../hooks/useSharedSolutions';
 import { SharedImpactsOverlay } from '../SharedImpacts/SharedImpacts';
 import { SharedSolutionsOverlay } from '../SharedSolutions/SharedSolutions';
+import { TLocation } from '../../../types/Location';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -75,7 +76,7 @@ const useStyles = makeStyles((theme: Theme) =>
 const ShareSummary: React.FC = () => {
   const classes = useStyles();
   const { push } = useHistory();
-  const location = useLocation();
+  const location = useLocation<TLocation>();
   const { showToast } = useToast();
   const { conversationId } = useUserB();
   const { alignmentScoresId } = useAlignment();
@@ -96,6 +97,11 @@ const ShareSummary: React.FC = () => {
       }
     }
   );
+
+  var hasSharedAlready = false;
+  if (location.state.from?.includes('/shared/')) {
+    hasSharedAlready = true;
+  }
 
   useEffect(() => {
     if (data) {
@@ -141,6 +147,13 @@ const ShareSummary: React.FC = () => {
         id: conversationId,
         userAName: summary.userAName,
       },
+    });
+  };
+
+  const handleCreateAccount = () => {
+    push({
+      pathname: `${ROUTES_CONFIG.USERB_ROUTE_REGISTER}/${conversationId}`,
+      state: { from: location.pathname, id: conversationId },
     });
   };
 
@@ -284,24 +297,52 @@ const ShareSummary: React.FC = () => {
                 </Grid>
 
                 <FooterAppBar bgColor={COLORS.ACCENT10}>
-                  <Button
-                    style={{ border: '1px solid #07373B', marginRight: '8px' }}
-                    onClick={handleNotWow}
-                  >
-                    Not Now
-                  </Button>
+                  {!hasSharedAlready ? (
+                    <>
+                      <Button
+                        style={{
+                          border: '1px solid #07373B',
+                          marginRight: '8px',
+                        }}
+                        onClick={handleNotWow}
+                      >
+                        Not Now
+                      </Button>
 
-                  <Button
-                    variant="contained"
-                    data-testid="take-quiz-userb-button"
-                    color="primary"
-                    disableElevation
-                    disabled={!isSuccess}
-                    style={{ border: '1px solid #a347ff', marginLeft: '8px' }}
-                    onClick={handleShareWithUserA}
-                  >
-                    Share with {summary.userAName}
-                  </Button>
+                      <Button
+                        variant="contained"
+                        data-testid="take-quiz-userb-button"
+                        color="primary"
+                        disableElevation
+                        disabled={!isSuccess}
+                        style={{
+                          border: '1px solid #a347ff',
+                          marginLeft: '8px',
+                        }}
+                        onClick={handleShareWithUserA}
+                      >
+                        Share with {summary.userAName}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button
+                        variant="contained"
+                        data-testid="take-quiz-userb-button"
+                        color="primary"
+                        disableElevation
+                        disabled={!isSuccess}
+                        style={{
+                          border: '1px solid #a347ff',
+                          margin: '0 auto',
+                          display: 'block',
+                        }}
+                        onClick={handleCreateAccount}
+                      >
+                        Create Account
+                      </Button>
+                    </>
+                  )}
                 </FooterAppBar>
               </>
             )}

--- a/src/pages/userB/ShareSummary/ShareSummary.tsx
+++ b/src/pages/userB/ShareSummary/ShareSummary.tsx
@@ -99,8 +99,10 @@ const ShareSummary: React.FC = () => {
   );
 
   var hasSharedAlready = false;
-  if (location.state.from?.includes('/shared/')) {
-    hasSharedAlready = true;
+  if (location.state && location.state.from) {
+    if (location.state.from.includes('/shared/')) {
+      hasSharedAlready = true;
+    }
   }
 
   useEffect(() => {

--- a/src/pages/userB/ShareSummary/ShareSummary.tsx
+++ b/src/pages/userB/ShareSummary/ShareSummary.tsx
@@ -32,6 +32,7 @@ import { useSharedSolutions } from '../../../hooks/useSharedSolutions';
 import { SharedImpactsOverlay } from '../SharedImpacts/SharedImpacts';
 import { SharedSolutionsOverlay } from '../SharedSolutions/SharedSolutions';
 import { TLocation } from '../../../types/Location';
+import { useGetOneConversation } from '../../../hooks/useGetOneConversation';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -88,6 +89,7 @@ const ShareSummary: React.FC = () => {
   const { logError } = useErrorLogging();
   const { impacts } = useSharedImpacts();
   const { solutions } = useSharedSolutions();
+  const { conversation } = useGetOneConversation(conversationId);
 
   const { data, isLoading, isSuccess } = useQuery(
     ['summary', alignmentScoresId],
@@ -101,6 +103,12 @@ const ShareSummary: React.FC = () => {
   var hasSharedAlready = false;
   if (location.state && location.state.from) {
     if (location.state.from.includes('/shared/')) {
+      hasSharedAlready = true;
+    }
+  }
+
+  if (conversation) {
+    if (conversation.state) {
       hasSharedAlready = true;
     }
   }
@@ -158,6 +166,10 @@ const ShareSummary: React.FC = () => {
       state: { from: location.pathname, id: conversationId },
     });
   };
+
+  if (!conversation) {
+    return <Loader></Loader>;
+  }
 
   return (
     <main>

--- a/src/pages/userB/ShareSummary/ShareSummary.tsx
+++ b/src/pages/userB/ShareSummary/ShareSummary.tsx
@@ -210,7 +210,7 @@ const ShareSummary: React.FC = () => {
                 ) : (
                   <>
                     <PageTitle>Share Summary</PageTitle>
-                    
+
                     <Box textAlign="center" mb={5}>
                       <Typography variant="subtitle2">
                         Here are the topics you shared with

--- a/src/pages/userB/ShareSummary/ShareSummary.tsx
+++ b/src/pages/userB/ShareSummary/ShareSummary.tsx
@@ -188,16 +188,30 @@ const ShareSummary: React.FC = () => {
               <Loader />
             ) : (
               <>
-                <PageTitle>Sharing is caring!</PageTitle>
+                {!hasSharedAlready ? (
+                  <>
+                    <PageTitle>Sharing is caring!</PageTitle>
 
-                <Box textAlign="center" mb={5}>
-                  <Typography variant="subtitle2">
-                    Share the impact and solutions you selected with
-                    {` ${summary.userAName} `} and let them know which core
-                    values you share!
-                  </Typography>
-                </Box>
-
+                    <Box textAlign="center" mb={5}>
+                      <Typography variant="subtitle2">
+                        Share the impact and solutions you selected with
+                        {` ${summary.userAName} `} and let them know which core
+                        values you share!
+                      </Typography>
+                    </Box>
+                  </>
+                ) : (
+                  <>
+                    <PageTitle>Share Summary</PageTitle>
+                    
+                    <Box textAlign="center" mb={5}>
+                      <Typography variant="subtitle2">
+                        Here are the topics you shared with
+                        {` ${summary.userAName}`}.
+                      </Typography>
+                    </Box>
+                  </>
+                )}
                 <Grid
                   container
                   direction="column"
@@ -297,17 +311,21 @@ const ShareSummary: React.FC = () => {
                       </SummaryCard>
                     </Grid>
                   ))}
-                  <Box textAlign="center" mt={5}>
-                    <Typography
-                      className={classes.topMatchValue}
-                      variant="h5"
-                      component="h5"
-                    >
-                      We only share your matching core values, selected impact
-                      and solutions with {` ${summary.userAName}`}. No other
-                      information, in case you were wondering. :)
-                    </Typography>
-                  </Box>
+                  {!hasSharedAlready ? (
+                    <Box textAlign="center" mt={5}>
+                      <Typography
+                        className={classes.topMatchValue}
+                        variant="h5"
+                        component="h5"
+                      >
+                        We only share your matching core values, selected impact
+                        and solutions with {` ${summary.userAName}`}. No other
+                        information, in case you were wondering. :)
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <></>
+                  )}
                 </Grid>
 
                 <FooterAppBar bgColor={COLORS.ACCENT10}>


### PR DESCRIPTION
First time visiting the summary page:
![image](https://user-images.githubusercontent.com/78958483/196624287-a2953916-8167-46c7-a6b8-186bb1c245ba.png)

When pressing the button 'Shared Topics' on the /shared page, it leads back to the summary page but now it only has the 'Create Account' button.
![image](https://user-images.githubusercontent.com/78958483/196624296-a0cfdcb3-3c84-4652-8b28-2d43598214d7.png)
