### PR TITLE
Fix climate feed bug

### DIFF
--- a/cypress/integration/accountMenu.ts
+++ b/cypress/integration/accountMenu.ts
@@ -18,9 +18,9 @@ describe('User Account Menu', () => {
   it('lets the user change the password', () => {
     cy.get('#UpdateEmailButton').click({ force: true });
     cy.contains('test233e3@example.com');
-    cy.get('#newEmail').scrollIntoView().type('newEmail@example.com');
-    cy.get('#confirmNewEmail').scrollIntoView().type('newEmail@example.com');
-    cy.get('#password').scrollIntoView().type('Password123');
+    cy.get('#newEmail').scrollIntoView().type('newEmail@example.com', {force: true});
+    cy.get('#confirmNewEmail').scrollIntoView().type('newEmail@example.com', {force: true});
+    cy.get('#password').scrollIntoView().type('Password123', {force: true});
     cy.get('#ConfirmButton').scrollIntoView().click({ force: true });
     cy.contains(/Email updated!/i);
   });

--- a/cypress/integration/accountMenu.ts
+++ b/cypress/integration/accountMenu.ts
@@ -32,7 +32,7 @@ describe('User Account Menu', () => {
   });
 
   it('lets the user log out', () => {
-    cy.get('#LogoutButton').click();
+    cy.get('#LogoutButton').click({ force: true });
     cy.contains(/Goodbye!/i);
     cy.contains(/Personalize your understanding of climate change/i);
   });

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -23,7 +23,7 @@ const ClimateFeed: React.FC = () => {
 
   const fetchClimateFeedData = async () => {
     let quizId: string | undefined = undefined;
-  
+
     // If a user isn't logged in, we take the quizId from the localStorage, as
     // he just finished the quiz before seeing the feed.
     if (!isLoggedIn) {

--- a/src/pages/ClimateFeed.tsx
+++ b/src/pages/ClimateFeed.tsx
@@ -12,16 +12,18 @@ import PageTitle from '../components/PageTitle';
 import ScrollToTopOnMount from '../components/ScrollToTopOnMount';
 import Wrapper from '../components/Wrapper';
 import { useAuth } from '../hooks/auth/useAuth';
+import { useSession } from '../hooks/useSession';
 import { useToast } from '../hooks/useToast';
 import { TClimateEffects } from '../types/types';
 
 const ClimateFeed: React.FC = () => {
+  const { sessionId } = useSession();
   const { showToast } = useToast();
   const { isLoggedIn } = useAuth();
 
   const fetchClimateFeedData = async () => {
     let quizId: string | undefined = undefined;
-
+  
     // If a user isn't logged in, we take the quizId from the localStorage, as
     // he just finished the quiz before seeing the feed.
     if (!isLoggedIn) {
@@ -49,10 +51,12 @@ const ClimateFeed: React.FC = () => {
   >(undefined);
 
   useEffect(() => {
-    fetchClimateFeedData().then((res) => setClimateFeedData(res));
+    if (sessionId && sessionId !== '') {
+      fetchClimateFeedData().then((res) => setClimateFeedData(res));
+    }
 
     // eslint-disable-next-line
-  }, [isLoggedIn]);
+  }, [isLoggedIn, sessionId]);
 
   if (climateFeedData === undefined) {
     return <Loader />;


### PR DESCRIPTION
When refreshing the page, the api call was failing due to a missing sessionId, so now we wait until the sessionId exists.