### PR TITLE
Fix page scrolling bugs

### DIFF
--- a/src/components/PageContentFlex.tsx
+++ b/src/components/PageContentFlex.tsx
@@ -9,8 +9,6 @@ const PageContent: React.FC = ({ children }) => {
     createStyles({
       root: {
         width: '100%',
-        maxWidth: '640px',
-        height: `calc(100vh - 75px )`,
         overflow: 'hidden',
       },
       spacer: theme.mixins.toolbar,

--- a/src/pages/SubmitSetTwo.tsx
+++ b/src/pages/SubmitSetTwo.tsx
@@ -20,7 +20,7 @@ const SubmitSetTwo: React.FC<{}> = () => {
   }, [sessionId]);
 
   return (
-    <>
+    <div style={{ minHeight: '600px' }}>
       <ScrollToTopOnMount />
       <Wrapper bgColor="#FF9439" fullHeight>
         <PageContentFlex>
@@ -60,7 +60,7 @@ const SubmitSetTwo: React.FC<{}> = () => {
           </Box>
         </PageContentFlex>
       </Wrapper>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Kameron noticed, that for the two pages /submit and /submit-set-two, a user wasn't able to scoll the page and therefore couldn't continue beacause the button was out of view.