### PR TITLE
[Closes #391] Rename toast message for copying link

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/src/hooks/useCopyLink.ts
+++ b/src/hooks/useCopyLink.ts
@@ -8,7 +8,7 @@ export const useCopyLink = () => {
   const clipboard = useClipboard({
     onSuccess() {
       showToast({
-        message: 'Link added!',
+        message: 'Link copied!',
         type: 'success',
       });
     },


### PR DESCRIPTION
Change toast message from 'Link added' to 'Link copied'