### PR TITLE
[#563 ] - Hide the CmAppBar when doing the User B conversation and logged in or logged out

### DIFF
--- a/src/pages/SharedPages/RootPage.tsx
+++ b/src/pages/SharedPages/RootPage.tsx
@@ -1,18 +1,18 @@
-import { useEffect, useState } from "react";
-import { Outlet, useLocation } from "react-router-dom";
+import { useEffect, useState } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 
-import { useAppDispatch, useAppSelector } from "store/hooks";
-import { CmAppBar, CmBottomTabsNavigation, CookieDialog, MenuDrawer } from "shared/components";
-import { useApiClient } from "shared/hooks";
-import { updateUserAInfo, updateUserBInfo, useAutoLogin } from "features/auth";
+import { useAppDispatch, useAppSelector } from 'store/hooks';
+import { CmAppBar, CmBottomTabsNavigation, CookieDialog, MenuDrawer } from 'shared/components';
+import { useApiClient } from 'shared/hooks';
+import { updateUserAInfo, updateUserBInfo, useAutoLogin } from 'features/auth';
 
-function RootPage() {
+function RootPage({ shouldHideCmBar }: { shouldHideCmBar: boolean }) {
   useAutoLogin();
   const location = useLocation();
 
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const { sessionId } = useAppSelector(state => state.auth.userA);
+  const { sessionId } = useAppSelector((state) => state.auth.userA);
 
   const [showMenu, setShowMenu] = useState(false);
 
@@ -33,9 +33,7 @@ function RootPage() {
 
   return (
     <div style={styles.root}>
-      <header style={styles.header}>
-        <CmAppBar onShowMenu={() => setShowMenu(true)} />
-      </header>
+      <header style={styles.header}>{!shouldHideCmBar && <CmAppBar onShowMenu={() => setShowMenu(true)} />}</header>
 
       <main style={styles.main}>
         <Outlet />
@@ -53,12 +51,12 @@ function RootPage() {
 
 const styles: { [key: string]: React.CSSProperties } = {
   root: {
-    display: "flex",
-    flexDirection: "column",
-    minHeight: "100vh",
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
   },
   header: {
-    position: "sticky",
+    position: 'sticky',
     top: 0,
     display: 'flex',
     alignItems: 'center',
@@ -82,7 +80,7 @@ const styles: { [key: string]: React.CSSProperties } = {
     textAlign: 'center',
   },
   footer: {
-    position: "sticky",
+    position: 'sticky',
     bottom: 0,
     display: 'flex',
     alignItems: 'center',

--- a/src/pages/SharedPages/RootPage.tsx
+++ b/src/pages/SharedPages/RootPage.tsx
@@ -6,7 +6,7 @@ import { CmAppBar, CmBottomTabsNavigation, CookieDialog, MenuDrawer } from 'shar
 import { useApiClient } from 'shared/hooks';
 import { updateUserAInfo, updateUserBInfo, useAutoLogin } from 'features/auth';
 
-function RootPage({ shouldHideCmBar }: { shouldHideCmBar: boolean }) {
+function RootPage({ shouldDisplayCmBar }: { shouldDisplayCmBar: boolean }) {
   useAutoLogin();
   const location = useLocation();
 
@@ -33,7 +33,7 @@ function RootPage({ shouldHideCmBar }: { shouldHideCmBar: boolean }) {
 
   return (
     <div style={styles.root}>
-      <header style={styles.header}>{!shouldHideCmBar && <CmAppBar onShowMenu={() => setShowMenu(true)} />}</header>
+      <header style={styles.header}>{!shouldDisplayCmBar && <CmAppBar onShowMenu={() => setShowMenu(true)} />}</header>
 
       <main style={styles.main}>
         <Outlet />

--- a/src/pages/UserAUnauthorizedPages/HideAppBarPage.tsx
+++ b/src/pages/UserAUnauthorizedPages/HideAppBarPage.tsx
@@ -1,8 +1,0 @@
-import { CmAppBar } from 'shared/components';
-
-function HideAppBarPage() {
-  // this should be a redux state
-  const isHidden = false;
-
-  return <>{isHidden && <CmAppBar onShowMenu={} />}</>;
-}

--- a/src/pages/UserAUnauthorizedPages/HideAppBarPage.tsx
+++ b/src/pages/UserAUnauthorizedPages/HideAppBarPage.tsx
@@ -1,0 +1,8 @@
+import { CmAppBar } from 'shared/components';
+
+function HideAppBarPage() {
+  // this should be a redux state
+  const isHidden = false;
+
+  return <>{isHidden && <CmAppBar onShowMenu={} />}</>;
+}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -42,10 +42,16 @@ import Error404Page from 'pages/SharedPages/Error404Page';
 import AuthorizedPage from 'pages/SharedPages/AuthorizedPage';
 import UnauthorizedPage from 'pages/UserAUnauthorizedPages/UnauthorizedPage';
 
+const userBRoutes = ['landing', 'how-cm-works', 'questionnaire', 'core-values', 'shared-values-user-b', 'shared-impacts', 'shared-solutions', 'shared-summary', 'shared', 'sign-up-user-b'];
+
+const userBRoutePath = location.pathname.split('/')[1];
+
+const shouldHideCmNavigationBar = userBRoutes.includes(userBRoutePath);
+
 const router = createBrowserRouter([
   {
     path: '',
-    element: <RootPage />,
+    element: <RootPage shouldHideCmBar={shouldHideCmNavigationBar} />,
     errorElement: <Error404Page />,
     children: [
       // UserA unauthorized pages

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -51,7 +51,7 @@ const shouldHideCmNavigationBar = userBRoutes.includes(userBRoutePath);
 const router = createBrowserRouter([
   {
     path: '',
-    element: <RootPage shouldHideCmBar={shouldHideCmNavigationBar} />,
+    element: <RootPage shouldDisplayCmBar={shouldHideCmNavigationBar} />,
     errorElement: <Error404Page />,
     children: [
       // UserA unauthorized pages


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
<!-- You can skip this if you're fixing a typo or doing any similar minor modifications -->

### Detailed information:
[#563] remove the app bar when doing the conversation and logged in
Explain the **details** of making this change. 
Please provide enough information so that others can review your pull request

Created logic in the router.ts file that allows us to hide the CmAppBar for User B's conversation journey only.  Used location.pathname to get the path of the routes that are applicable. 

Used this to link to a prop in the RoutePage which allows us to pass a boolean to show the CmAppBar

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Closing issues: 

List all issues the pull request solve: 

[#562](https://github.com/ClimateMind/climatemind-frontend/issues/562)

<!-- Put `closes #XXXX` in your commit message to auto-close the issue that your PR fixes. -->
closes #562 
### Test plan (required)

<!-- Check all steps below and mark completed -->

- [ ] The PR contains new PyTest unit/integration tests for any function or functional added. 
- [ ] The PR changes existing PyTest unit/integration tests to keep all tests up to date.
- [ ] The PR does not lead to degradation in unit test coverage.
- [ ] Project parts affected by changes in this PR was tested manually on your local (using Postman or in any other way). List everything you've tested below:
  - *Part 1*
  - *Part 2*

<!-- Make sure tests pass on Circle CI. -->


