### PR TITLE
chore: Add Content-Security-Policy header to nginx.config

### DIFF
--- a/nginx.config
+++ b/nginx.config
@@ -15,5 +15,6 @@ server {
     add_header X-Frame-Options DENY;
     add_header X-XSS-Protection "1; mode=block";
     add_header Feature-Policy "accelerometer 'none'; camera 'none'; microphone 'none'";
+     add_header Content-Security-Policy "script-src 'self' https://www.googletagmanager.com/ https://*.google-analytics.com https://*.analytics.google.com https://www.google.com/ https://www.gstatic.com/ https://accounts.google.com 'unsafe-inline' 'unsafe-eval'";
 
 }


### PR DESCRIPTION
adding in line  add_header Content-Security-Policy "script-src 'self' https://www.googletagmanager.com/ https://*.google-analytics.com https://*.analytics.google.com https://www.google.com/ https://www.gstatic.com/ https://accounts.google.com 'unsafe-inline' 'unsafe-eval'";