### PR TITLE
[686] - create code for refreshing google auth token

### DIFF
--- a/src/api/responses.ts
+++ b/src/api/responses.ts
@@ -55,6 +55,7 @@ export type Login = {
 export type googleLogin = {
   message: string;
   access_token: string;
+  refresh_token: string;
   user: {
     email: string;
     first_name: string;

--- a/src/features/auth/hooks/useLogin.tsx
+++ b/src/features/auth/hooks/useLogin.tsx
@@ -8,7 +8,7 @@ function useLogin() {
   const dispatch = useAppDispatch();
   const quizIdB = useAppSelector((state) => state.auth.userB.quizId);
   const quizIdA = useAppSelector((state) => state.auth.userA.quizId);
-  
+
   const apiClient = useApiClient();
   const { showSuccessToast, showErrorToast } = useToastMessage();
 

--- a/src/pages/UserBPages/UserBSignUpPage.tsx
+++ b/src/pages/UserBPages/UserBSignUpPage.tsx
@@ -21,6 +21,7 @@ function UserBSignUpPage() {
   const { signUp } = useSignUp();
   const [isLoading, setIsLoading] = useState(false);
   const devMode = localStorage.getItem('devMode') === 'true';
+
   async function signUpHandler(firstName: string, lastName: string, email: string, password: string) {
     setIsLoading(true);
     const success = await signUp(firstName, lastName, email, password, quizId);
@@ -47,9 +48,7 @@ function UserBSignUpPage() {
         <CmTypography variant="h1">Welcome to Climate Mind</CmTypography>
 
         <div style={{ display: 'flex' }}>
-          <CmTypography variant="body" style={{ textAlign: 'center' }}>
-            Already have an account?
-          </CmTypography>
+          <CmTypography variant="body" style={{ textAlign: 'center' }}>Already have an account?</CmTypography>
           <CmButton variant="text" text="Login" onClick={() => navigate(ROUTES.LOGIN_PAGE)} style={styles.loginButton} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 19, justifyContent: 'center', alignItems: 'center' }}>

--- a/src/pages/UserBPages/UserBSignUpPage.tsx
+++ b/src/pages/UserBPages/UserBSignUpPage.tsx
@@ -20,7 +20,7 @@ function UserBSignUpPage() {
   const { sessionId, quizId } = useAppSelector((state) => state.auth.userB);
   const { signUp } = useSignUp();
   const [isLoading, setIsLoading] = useState(false);
-
+  const devMode = localStorage.getItem('devMode') === 'true';
   async function signUpHandler(firstName: string, lastName: string, email: string, password: string) {
     setIsLoading(true);
     const success = await signUp(firstName, lastName, email, password, quizId);
@@ -47,13 +47,15 @@ function UserBSignUpPage() {
         <CmTypography variant="h1">Welcome to Climate Mind</CmTypography>
 
         <div style={{ display: 'flex' }}>
-          <CmTypography variant="body" style={{ textAlign: 'center' }}>Already have an account?</CmTypography>
+          <CmTypography variant="body" style={{ textAlign: 'center' }}>
+            Already have an account?
+          </CmTypography>
           <CmButton variant="text" text="Login" onClick={() => navigate(ROUTES.LOGIN_PAGE)} style={styles.loginButton} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 19, justifyContent: 'center', alignItems: 'center' }}>
           <SignUpForm isLoading={isLoading} onSignUp={signUpHandler} />
           <div style={{ borderBottom: '1px solid #0000001A', height: 1, width: 205 }}></div>
-          <GoogleLogin navigateAfterLogin={navigateAfterLogin} text="Continue With Google" />
+          {devMode && <GoogleLogin navigateAfterLogin={navigateAfterLogin} text="Continue With Google" />}
         </div>
       </PageContent>
     </Page>

--- a/src/shared/hooks/useApiClient.tsx
+++ b/src/shared/hooks/useApiClient.tsx
@@ -8,6 +8,8 @@ import { useToastMessage } from 'shared/hooks';
 import * as requests from 'api/requests';
 import * as responses from 'api/responses';
 import { ClimateEffect, Solution, Myth } from 'shared/types';
+// import { useNavigate } from 'react-router-dom';
+// import ROUTES from 'router/RouteConfig';
 
 const baseUrl = process.env.REACT_APP_API_URL;
 
@@ -26,24 +28,53 @@ const validateToken = (token: string): boolean => {
 
 function useApiClient() {
   const { showErrorToast } = useToastMessage();
-
+  // const navigate = useNavigate();
   const sessionId = useAppSelector((state) => state.auth.userA.sessionId);
   const quizId = useAppSelector((state) => state.auth.userA.quizId);
 
-  async function apiCall<T>(method: string, endpoint: string, headers: { [key: string]: string }, data?: any, withCredentials?: boolean) {
+  async function apiCall<T>(method: string, endpoint: string, headers: { [key: string]: string }, data?: any, withCredentials?: boolean, customCookies?: { [key: string]: string }) {
     // Add sessionId to headers
     if (sessionId) {
       headers['X-Session-Id'] = sessionId;
     }
 
+    if (customCookies) {
+      Object.entries(customCookies).forEach(([key, value]) => {
+        Cookies.set(key, value, { secure: true, sameSite: 'strict' });
+      });
+    }
     // Get access token from cookies
-    const accessToken = Cookies.get('accessToken');
+    let accessToken = Cookies.get('accessToken');
     if (accessToken) {
+      console.log('Access Token exists:', accessToken);
+
+      // Check if the token is valid
       if (!validateToken(accessToken)) {
-        Cookies.remove('accessToken');
-        // const newAccessToken = await postRefresh();
-        // headers['Authorization'] = 'Bearer ' + newAccessToken;
-      } else {
+        console.log('Access Token expired. Refreshing...');
+
+        // Attempt to refresh the access token
+        const newAccessToken = await handleTokenRefresh();
+
+        // If a new token is received, update it in the cookies and set the Authorization header
+        if (newAccessToken) {
+          accessToken = newAccessToken;
+          Cookies.set('accessToken', accessToken);
+        } else {
+          // console.error('Failed to refresh token.');
+          // Optionally, redirect the user to login or handle the error appropriately
+          // navigate(ROUTES.LOGIN_PAGE);
+          // showErrorToast('Your session has expired. Please login again.');
+          // setTimeout(async () => {
+          //   window.location.reload();
+          // }, 2000); // Add a delay to allow the toast to show before redirecting
+        }
+        //   const refreshToken = Cookies.get('refreshToken');
+        //   if (refreshToken) {
+        //     headers['X-Refresh-Token'] = refreshToken; // Set refresh token in a custom header
+        //   }
+        // }
+
+        // Set the Authorization header with the valid (or refreshed) token
         headers['Authorization'] = 'Bearer ' + accessToken;
       }
     }
@@ -53,8 +84,14 @@ function useApiClient() {
       method,
       headers,
       data,
-      withCredentials,
+      withCredentials, // Always send credentials unless explicitly set to false
     });
+
+    if (customCookies) {
+      Object.keys(customCookies).forEach((key) => {
+        Cookies.remove(key);
+      });
+    }
 
     return response;
   }
@@ -62,7 +99,10 @@ function useApiClient() {
   async function postSession() {
     try {
       const response = await apiCall<responses.PostSession>('post', '/session', {});
-      return response.data;
+      if (response) {
+        return response.data;
+      }
+      throw new Error('Response is undefined');
     } catch (error) {
       console.log(error);
       return { sessionId: '' };
@@ -108,9 +148,17 @@ function useApiClient() {
 
   async function postRegister({ firstName, lastName, email, password, quizId }: requests.PostRegister) {
     const response = await apiCall<responses.PostRegister>('post', '/register', {}, { firstName, lastName, email, password, quizId });
-
-    // Store the access token for userA in cookies
     const accessToken = response.data.access_token;
+    // Store the access token for userA in cookies
+    if (response) {
+      if (!response) {
+        throw new Error('Response is undefined');
+      }
+
+      Cookies.set('accessToken', accessToken, { secure: true });
+    } else {
+      throw new Error('Response is undefined');
+    }
     Cookies.set('accessToken', accessToken, { secure: true });
 
     return response.data;
@@ -144,20 +192,40 @@ function useApiClient() {
     //   const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
     //   Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
     // }
-
+    // Set refresh token from response headers (if backend returns it)
+    const cookieHeader = response.headers['set-cookie'];
+    if (cookieHeader) {
+      const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
+      Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
+      console.log('Refresh token set:', refreshToken); // Add this log for debugging
+    }
     return response.data;
   }
 
   async function postGoogleLogin(credential: string, quizId: string) {
-    if (quizId) {
-      const response = await apiCall<responses.googleLogin>('post', '/auth/google', {}, { credential, quizId }, true);
-      return response.data;
-    }
+    // if (quizId) {
+    const response = await apiCall<responses.googleLogin>('post', '/auth/google', {}, { credential, quizId }, true);
+    const { access_token, refresh_token } = response.data;
+    console.log('Access token:', access_token);
 
-    const response = await apiCall<responses.googleLogin>('post', '/auth/google', {}, { credential }, true);
-    const { access_token } = response.data;
-    Cookies.set('accessToken', access_token, { secure: true, sameSite: 'strict' });
+    Cookies.set('accessToken', access_token, { secure: true });
+    Cookies.set('refreshToken', refresh_token, {
+      secure: true,
+      sameSite: 'strict',
+      path: '/',
+    });
+    console.log(Cookies.get('refreshToken'), 'refreshToken');
+    // const cookieHeader = response.headers['set-cookie'];
+    // if (cookieHeader) {
+    //   // const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
+    //   Cookies.set('refreshToken', refresh_token, { expires: 365, secure: true });
+    //   console.log('Refresh token set:', refresh_token); // Add this log for debugging
+    // }
     return response.data;
+    // } else {
+    //   const response = await apiCall<responses.googleLogin>('post', '/auth/google', {}, { credential }, true);
+    //   return response.data;
+    // }
   }
 
   async function postLogout() {
@@ -167,29 +235,56 @@ function useApiClient() {
     await apiCall('post', '/logout', {});
   }
 
+  async function handleTokenRefresh(): Promise<string | undefined> {
+    const newToken = await postRefresh();
+    console.log(newToken, 'newToken');
+
+    if (newToken) {
+      Cookies.set('accessToken', newToken, { secure: true });
+      return newToken;
+    } else {
+      // Handle the error case where the refresh failed
+
+      console.error('Failed to refresh token.');
+
+      // showErrorToast('Your session has expired. Please log in again.');
+      // postLogout();
+
+      // throw new Error('Token refresh failed');
+    }
+  }
+
   async function postRefresh(): Promise<string> {
+    // Cookies.set('refreshToken', 'refreshToken', { secure: true });
     // Get the refresh token from cookies
+    Cookies.remove('accessToken');
     const refreshToken = Cookies.get('refreshToken');
+    console.log('Retrieved refresh token from cookies:', refreshToken);
 
     if (!refreshToken) {
       return '';
     }
 
     try {
-      const response = await apiCall<{ access_token: string }>('post', '/refresh', {
-        Cookie: 'refreshToken=' + refreshToken,
-      });
+      const response = await apiCall<{ access_token: string }>(
+        'post',
+        '/refresh',
+        {}, // Remove Authorization header
+        {},
+        true,
+        { refresh_token: refreshToken }
+      );
 
       // Update the access token in cookies
       const accessToken = response.data.access_token;
       Cookies.set('accessToken', accessToken, { secure: true });
-
+      console.log('New access token:', accessToken);
       // Update the refresh token in cookies
-      const cookieHeader = response.headers['set-cookie'];
-      if (cookieHeader) {
-        const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
-        Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
-      }
+      // const cookieHeader = response.headers['set-cookie'];
+      // if (cookieHeader) {
+      //   const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
+      //   Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
+      // }
 
       return accessToken;
     } catch (error) {
@@ -279,7 +374,7 @@ function useApiClient() {
   }
 
   async function getAllConversations() {
-    const response = await apiCall<{ conversations: responses.GetAllConversations[] }>('get', '/conversations', {});
+    const response = await apiCall<{ conversations: responses.GetAllConversations[] }>('get', '/conversations', { Authorization: `Bearer ${Cookies.get('accessToken')}` }, {});
 
     return response.data;
   }
@@ -490,7 +585,7 @@ function useApiClient() {
     postSharedSolutions,
     getAlignmentSummary,
     postConversationConsent,
-
+    handleTokenRefresh,
     postUserBVisit,
   };
 }

--- a/src/shared/hooks/useApiClient.tsx
+++ b/src/shared/hooks/useApiClient.tsx
@@ -3,13 +3,10 @@ import Cookies from 'js-cookie';
 import { jwtDecode } from 'jwt-decode';
 
 import { useAppSelector } from 'store/hooks';
-// import { useLogout } from 'features/auth';
 import { useToastMessage } from 'shared/hooks';
 import * as requests from 'api/requests';
 import * as responses from 'api/responses';
 import { ClimateEffect, Solution, Myth } from 'shared/types';
-// import { useNavigate } from 'react-router-dom';
-// import ROUTES from 'router/RouteConfig';
 
 const baseUrl = process.env.REACT_APP_API_URL;
 
@@ -28,7 +25,6 @@ const validateToken = (token: string): boolean => {
 
 function useApiClient() {
   const { showErrorToast } = useToastMessage();
-  // const navigate = useNavigate();
   const sessionId = useAppSelector((state) => state.auth.userA.sessionId);
   const quizId = useAppSelector((state) => state.auth.userA.quizId);
 
@@ -46,12 +42,8 @@ function useApiClient() {
     // Get access token from cookies
     let accessToken = Cookies.get('accessToken');
     if (accessToken) {
-      console.log('Access Token exists:', accessToken);
-
       // Check if the token is valid
       if (!validateToken(accessToken)) {
-        console.log('Access Token expired. Refreshing...');
-
         // Attempt to refresh the access token
         const newAccessToken = await handleTokenRefresh();
 
@@ -60,19 +52,11 @@ function useApiClient() {
           accessToken = newAccessToken;
           Cookies.set('accessToken', accessToken);
         } else {
-          // console.error('Failed to refresh token.');
-          // Optionally, redirect the user to login or handle the error appropriately
-          // navigate(ROUTES.LOGIN_PAGE);
-          // showErrorToast('Your session has expired. Please login again.');
-          // setTimeout(async () => {
-          //   window.location.reload();
-          // }, 2000); // Add a delay to allow the toast to show before redirecting
+          showErrorToast('Your session has expired. Please login again.');
+          setTimeout(async () => {
+            window.location.reload();
+          }, 2000); // Add a delay to allow the toast to show before redirecting
         }
-        //   const refreshToken = Cookies.get('refreshToken');
-        //   if (refreshToken) {
-        //     headers['X-Refresh-Token'] = refreshToken; // Set refresh token in a custom header
-        //   }
-        // }
 
         // Set the Authorization header with the valid (or refreshed) token
         headers['Authorization'] = 'Bearer ' + accessToken;
@@ -185,47 +169,26 @@ function useApiClient() {
       Cookies.set('accessToken', accessToken, { secure: true });
     }
 
-    // Store the refresh token in cookies
-    // const cookieHeader = response.headers['set-cookie'];
-
-    // if (cookieHeader) {
-    //   const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
-    //   Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
-    // }
     // Set refresh token from response headers (if backend returns it)
     const cookieHeader = response.headers['set-cookie'];
     if (cookieHeader) {
       const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
       Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
-      console.log('Refresh token set:', refreshToken); // Add this log for debugging
     }
     return response.data;
   }
 
   async function postGoogleLogin(credential: string, quizId: string) {
-    // if (quizId) {
     const response = await apiCall<responses.googleLogin>('post', '/auth/google', {}, { credential, quizId }, true);
     const { access_token, refresh_token } = response.data;
-    console.log('Access token:', access_token);
-
     Cookies.set('accessToken', access_token, { secure: true });
     Cookies.set('refreshToken', refresh_token, {
       secure: true,
       sameSite: 'strict',
       path: '/',
     });
-    console.log(Cookies.get('refreshToken'), 'refreshToken');
-    // const cookieHeader = response.headers['set-cookie'];
-    // if (cookieHeader) {
-    //   // const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
-    //   Cookies.set('refreshToken', refresh_token, { expires: 365, secure: true });
-    //   console.log('Refresh token set:', refresh_token); // Add this log for debugging
-    // }
+
     return response.data;
-    // } else {
-    //   const response = await apiCall<responses.googleLogin>('post', '/auth/google', {}, { credential }, true);
-    //   return response.data;
-    // }
   }
 
   async function postLogout() {
@@ -237,54 +200,34 @@ function useApiClient() {
 
   async function handleTokenRefresh(): Promise<string | undefined> {
     const newToken = await postRefresh();
-    console.log(newToken, 'newToken');
 
     if (newToken) {
       Cookies.set('accessToken', newToken, { secure: true });
       return newToken;
     } else {
-      // Handle the error case where the refresh failed
-
-      console.error('Failed to refresh token.');
-
-      // showErrorToast('Your session has expired. Please log in again.');
-      // postLogout();
-
-      // throw new Error('Token refresh failed');
+      showErrorToast('Your session has expired. Please login again.');
+      setTimeout(async () => {
+        window.location.reload();
+      }, 2000); // Add a delay to allow the toast to show before redirecting
     }
   }
 
   async function postRefresh(): Promise<string> {
-    // Cookies.set('refreshToken', 'refreshToken', { secure: true });
     // Get the refresh token from cookies
     Cookies.remove('accessToken');
     const refreshToken = Cookies.get('refreshToken');
-    console.log('Retrieved refresh token from cookies:', refreshToken);
 
     if (!refreshToken) {
+      showErrorToast('Refresh token not found. Please log in again.');
       return '';
     }
 
     try {
-      const response = await apiCall<{ access_token: string }>(
-        'post',
-        '/refresh',
-        {}, // Remove Authorization header
-        {},
-        true,
-        { refresh_token: refreshToken }
-      );
+      const response = await apiCall<{ access_token: string }>('post', '/refresh', {}, {}, true, { refresh_token: refreshToken });
 
       // Update the access token in cookies
       const accessToken = response.data.access_token;
       Cookies.set('accessToken', accessToken, { secure: true });
-      console.log('New access token:', accessToken);
-      // Update the refresh token in cookies
-      // const cookieHeader = response.headers['set-cookie'];
-      // if (cookieHeader) {
-      //   const refreshToken = cookieHeader[0].split(';')[0].split('=')[1];
-      //   Cookies.set('refreshToken', refreshToken, { expires: 365, secure: true });
-      // }
 
       return accessToken;
     } catch (error) {

--- a/src/shared/hooks/useApiClient.tsx
+++ b/src/shared/hooks/useApiClient.tsx
@@ -33,6 +33,7 @@ function useApiClient() {
     if (sessionId) {
       headers['X-Session-Id'] = sessionId;
     }
+    //customCookies is used to set cookies (In this instance it is the refresh token) for the request and remove them after the request is done.
 
     if (customCookies) {
       Object.entries(customCookies).forEach(([key, value]) => {

--- a/src/shared/hooks/useApiClient.tsx
+++ b/src/shared/hooks/useApiClient.tsx
@@ -368,7 +368,7 @@ function useApiClient() {
   }
 
   async function createConversationInvite(invitedUserName: string) {
-    const response = await apiCall<responses.CreateConversation>('post', '/conversation', {}, { invitedUserName });
+    const response = await apiCall<responses.CreateConversation>('post', '/conversation', { Authorization: `Bearer ${Cookies.get('accessToken')}` }, { invitedUserName });
 
     return response.data;
   }
@@ -386,7 +386,7 @@ function useApiClient() {
   }
 
   async function deleteConversation(conversationId: string) {
-    await apiCall('delete', '/conversation/' + conversationId, {});
+    await apiCall('delete', '/conversation/' + conversationId, { Authorization: `Bearer ${Cookies.get('accessToken')}` });
   }
 
   async function putSingleConversation(data: requests.PutSingleConversation) {

--- a/src/shared/hooks/useApiClient.tsx
+++ b/src/shared/hooks/useApiClient.tsx
@@ -33,13 +33,14 @@ function useApiClient() {
     if (sessionId) {
       headers['X-Session-Id'] = sessionId;
     }
-    //customCookies is used to set cookies (In this instance it is the refresh token) for the request and remove them after the request is done.
 
+    // customCookies is used to set cookies (In this instance it is the refresh token) for the request and remove them after the request is done.
     if (customCookies) {
       Object.entries(customCookies).forEach(([key, value]) => {
         Cookies.set(key, value, { secure: true, sameSite: 'strict' });
       });
     }
+
     // Get access token from cookies
     let accessToken = Cookies.get('accessToken');
     if (accessToken) {
@@ -134,6 +135,7 @@ function useApiClient() {
   async function postRegister({ firstName, lastName, email, password, quizId }: requests.PostRegister) {
     const response = await apiCall<responses.PostRegister>('post', '/register', {}, { firstName, lastName, email, password, quizId });
     const accessToken = response.data.access_token;
+
     // Store the access token for userA in cookies
     if (response) {
       if (!response) {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
<!-- You can skip this if you're fixing a typo or doing any similar minor modifications -->

### Detailed information:

I have made several changes to the code. In the useApi hook I created a new function called handleTokenRefresh which calls the postRefresh function. I have also added a customCookies param to the apiCall function so that we can pass the RefreshToken. I don't know why but the backend wouldn't accept the token as part of the headers or the body.
I also removed the Access Token in the postRefesh function at the beginning so it would use the new access token and not the old expired one.

You can test this on local by setting  JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=1) on the current backend.  If it doesn't work then you can wait for the new backend changes in a separate PR. https://github.com/ClimateMind/climatemind-backend/pull/540

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Closing issues: 

List all issues the pull request solve: 

- #685


<!-- Put `closes #XXXX` in your commit message to auto-close the issue that your PR fixes. -->
closes #686 
### Test plan (required)

<!-- Check all steps below and mark completed -->

- [ ] The PR contains new PyTest unit/integration tests for any function or functional added. 
- [ ] The PR changes existing PyTest unit/integration tests to keep all tests up to date.
- [ ] The PR does not lead to degradation in unit test coverage.
- [ ] Project parts affected by changes in this PR was tested manually on your local (using Postman or in any other way). List everything you've tested below:
  - *Part 1*
  - *Part 2*

<!-- Make sure tests pass on Circle CI. -->


